### PR TITLE
Update references to external repos to pick up changes needed for Bazel 0.20.0

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -158,7 +158,7 @@ def com_google_protobuf(**kwargs):
 def com_github_grpc_grpc(**kwargs):
     name = "com_github_grpc_grpc"
     ref = get_ref(name, "d6c989936c0d6fdaf481e4ac460beaebc6c57f20", kwargs) # v1.17.0
-    sha256 = get_sha256(name, "8c09d35806c857dcb3a383c81052cc7ba1c5855e827d0792a83bd57251821e29", kwargs)
+    sha256 = get_sha256(name, "1b1e4d9b5d38000149501d1719d2947f62ed32a79b5f8fe932f6286689257d7a", kwargs)
     github_archive(name, "grpc", "grpc", ref, sha256)
 
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -142,8 +142,8 @@ def boringssl(**kwargs):
 
 def com_github_nanopb_nanopb(**kwargs):
     name = "com_github_nanopb_nanopb"
-    ref = get_ref(name, "5f85445781ef29e50435c2eea661ca435a19b6bc", kwargs) 
-    sha256 = get_sha256(name, "8c09d35806c857dcb3a383c81052cc7ba1c5855e827d1792a83bd57251821e29", kwargs)
+    ref = get_ref(name, "ae9901f2a31500e8fdc93fa9804d24851c58bb1e", kwargs)
+    sha256 = get_sha256(name, "7aa0ab179eff56241b6cded9cd07324af2395ad56d5478e2f7dabdb42b65d3fb", kwargs)
     github_archive(name, "nanopb", "nanopb", ref, sha256)
 
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -157,8 +157,8 @@ def com_google_protobuf(**kwargs):
 
 def com_github_grpc_grpc(**kwargs):
     name = "com_github_grpc_grpc"
-    ref = get_ref(name, "d6c989936c0d6fdaf481e4ac460beaebc6c57f20", kwargs) # v1.17.0
-    sha256 = get_sha256(name, "1b1e4d9b5d38000149501d1719d2947f62ed32a79b5f8fe932f6286689257d7a", kwargs)
+    ref = get_ref(name, "f0fbee59326402e6c1f0a7c6a1f8899fd2b0025a", kwargs) # Bazel 0.20.0 workspace fixes.
+    sha256 = get_sha256(name, "6cea8d3dbe289872343aafe67736539b0a28ecd062d3ff4965f157f5d9d77d1d", kwargs)
     github_archive(name, "grpc", "grpc", ref, sha256)
 
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -157,7 +157,7 @@ def com_google_protobuf(**kwargs):
 
 def com_github_grpc_grpc(**kwargs):
     name = "com_github_grpc_grpc"
-    ref = get_ref(name, "5f84445781ef29e50435c2eea661ca435a19b6bc", kwargs) # v1.15.0
+    ref = get_ref(name, "d6c989936c0d6fdaf481e4ac460beaebc6c57f20", kwargs) # v1.17.0
     sha256 = get_sha256(name, "8c09d35806c857dcb3a383c81052cc7ba1c5855e827d0792a83bd57251821e29", kwargs)
     github_archive(name, "grpc", "grpc", ref, sha256)
 


### PR DESCRIPTION
dependent repos are using native http_archive that has been deprecated.
rules_k8s cannot run (w/o an extra flag) until we fix these issues and pin to after this commit.
