### PR TITLE
Add javax annotation API dependency to //java:proto_deps

### DIFF
--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -19,6 +19,7 @@ java_library(
     exports = [
         "@com_google_guava_guava//jar",
         "@com_google_protobuf//:protobuf_java",
+        "@javax_annotation_javax_annotation_api//jar",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Fixes #18 

This fixes compilation errors when using Java 9. With Java 8 the javax annotation API classes are included implicitly, but with Java 9 the dependency needs to be explicit. This is a safe dependency for both Java 8 and 9.

See related gRPC discussion: https://github.com/grpc/grpc-java/issues/3633

The native `java_grpc_library()` rule in Bazel was fixed by adding the dependency on javax.annotation-api as well: https://github.com/bazelbuild/bazel/pull/5017