### PR TITLE
Update com_google_protobuf version to v3.6.1.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,13 +7,13 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 # =========================================
 
-PROTOBUF_VERSION = "b829ff2a4614ff25048944b2cdc8e43b6488fda0"
+PROTOBUF_VERSION = "3.6.1.3"
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "5d82a718e271e7fda626f983628e4b4601221788c2244763a9e57eda4cc667dd",
+    sha256 = "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a",
     strip_prefix = "protobuf-" + PROTOBUF_VERSION,
-    url = "https://github.com/google/protobuf/archive/%s.tar.gz" % PROTOBUF_VERSION,
+    url = "https://github.com/google/protobuf/archive/v%s.tar.gz" % PROTOBUF_VERSION,
 )
 
 # =========================================

--- a/deps.bzl
+++ b/deps.bzl
@@ -130,8 +130,8 @@ def com_github_nanopb_nanopb(**kwargs):
 
 def com_google_protobuf(**kwargs):
     name = "com_google_protobuf"
-    ref = get_ref(name, "b829ff2a4614ff25048944b2cdc8e43b6488fda0", kwargs)
-    sha256 = get_sha256(name, "5d82a718e271e7fda626f983628e4b4601221788c2244763a9e57eda4cc667dd", kwargs)
+    ref = get_ref(name, "v3.6.1.3", kwargs)
+    sha256 = get_sha256(name, "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a", kwargs)
     github_archive(name, "google", "protobuf", ref, sha256)
 
 def com_github_grpc_grpc(**kwargs):


### PR DESCRIPTION
Newer bazel versions (0.21.0+) are incompatible with the `com_google_protobuf` version here, which is `v3.6.1.2`: https://github.com/protocolbuffers/protobuf/issues/5547

This PR increases the version to `v3.6.1.3`, which contains the bazel compatibility fixes.

Additionally, I switched from commit to tag on identifying the archive for readability.