### PR TITLE
Enable creation of gRPC mock code for C++.

### DIFF
--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -11,9 +11,13 @@ proto_plugin(
 
 proto_plugin(
     name = "grpc_cpp",
+    options = [
+        "generate_mock_code=true",
+    ],
     outputs = [
         "{basename}.grpc.pb.h",
         "{basename}.grpc.pb.cc",
+        "{basename}_mock.grpc.pb.h",
     ],
     tool = "@com_github_grpc_grpc//:grpc_cpp_plugin",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This rule adds another output file "_mock.grpc.pb.h" that contains the
gRPC's services mock definition. This feature of the gRPC proto compiler
is described in https://grpc.io/grpc/cpp/md_doc_unit_testing.html.

I think that this feature is generally useful enough to enable it for
all C++ gRPC users. I haven't found a reasonable way to enable it via a
flag, because the plugin options are set statically in BUILD.bazel and
the global options dict of proto_compile is also propagated to the C++
non-grpc compiler (which doesn't understand it).