### PR TITLE
Add google/protobuf exclude rule to python plugin transitivity

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -11,4 +11,7 @@ proto_plugin(
     outputs = ["_pb2_grpc.py"],
     tool = "@com_github_grpc_grpc//:grpc_python_plugin",
     visibility = ["//visibility:public"],
+    transitivity = {
+        "google/protobuf": "exclude",
+    },
 )


### PR DESCRIPTION
These proto files should not be built, as they are part of the default google.protobuf package ~~and the built versions are missing helper functions on the well-known types~~