### PR TITLE
android rules should only depend on protobuf lite.

### DIFF
--- a/android/BUILD.bazel
+++ b/android/BUILD.bazel
@@ -21,7 +21,7 @@ java_library(
     visibility = ["//visibility:public"],
     exports = [
         "@com_google_guava_guava_android//jar",
-        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf_lite//:protobuf_java_lite",
         "@javax_annotation_javax_annotation_api//jar",
     ],
 )

--- a/cpp/cpp_grpc_library.bzl
+++ b/cpp/cpp_grpc_library.bzl
@@ -17,9 +17,8 @@ def cpp_grpc_library(**kwargs):
         name = name,
         srcs = [name_pb],
         deps = [
-            "//external:protobuf_clib",
-            "@com_github_grpc_grpc//:grpc++",
-            "@com_github_grpc_grpc//:grpc++_reflection",
+            "@com_google_protobuf//:protobuf_lite",
+            "@com_github_grpc_grpc//:grpc++_codegen_proto",
         ],
         # This seems magical to me.
         includes = [name_pb],

--- a/cpp/cpp_proto_library.bzl
+++ b/cpp/cpp_proto_library.bzl
@@ -17,7 +17,7 @@ def cpp_proto_library(**kwargs):
         name = name,
         srcs = [name_pb],
         deps = [
-            "//external:protobuf_clib",
+            "@com_google_protobuf//:protobuf_lite",
         ],
         includes = [name_pb],
         visibility = visibility,

--- a/cpp/deps.bzl
+++ b/cpp/deps.bzl
@@ -2,7 +2,6 @@ load(
     "//:deps.bzl",
     "com_github_grpc_grpc",
     "com_google_protobuf",
-    "external_protobuf_clib",
 )
 
 def cpp_proto_compile(**kwargs):
@@ -14,7 +13,6 @@ def cpp_grpc_compile(**kwargs):
 
 def cpp_proto_library(**kwargs):
     cpp_proto_compile(**kwargs)
-    external_protobuf_clib(**kwargs)
 
 def cpp_grpc_library(**kwargs):
     cpp_grpc_compile(**kwargs)

--- a/deps.bzl
+++ b/deps.bzl
@@ -46,14 +46,6 @@ def get_sha1(name, default, kwargs):
     key = name + "_sha1"
     return kwargs.get(key, default)
 
-def external_protobuf_clib(**kwargs):
-    name = "protobuf_clib"
-    if name not in native.existing_rules():
-        native.bind(
-            name = name,
-            actual = "@com_google_protobuf//:protoc_lib",
-        )
-
 def external_protobuf_headers(**kwargs):
     name = "protobuf_headers"
     if name not in native.existing_rules():


### PR DESCRIPTION
having a dependency against java protobuf causes crashes in android java code.