### PR TITLE
Switch to newer com_google_protobuf_{java,}lite

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -278,8 +278,8 @@ def io_grpc_grpc_java(**kwargs):
     """grpc java plugin and jars
     """
     name = "io_grpc_grpc_java"
-    ref = get_ref(name, "fe7f043504d66e1b3f674c0514ce794c8a56884e", kwargs)  # v1.17.2
-    sha256 = get_sha256(name, "adc446334be8573035cee78d077f17dfebf3299a78b92ce2e5d39d184da6c948", kwargs)
+    ref = get_ref(name, "3c24dc6fe1b8f3e5c89b919c38a4eefe216397d3", kwargs)  # v1.19.0 and changes up to PR #5456
+    sha256 = get_sha256(name, "1eeb136874a58a0a311a0701016aced96919f501ced0372013eb1708724ab046", kwargs)
     github_archive(name, "grpc", "grpc-java", ref, sha256)
 
 def com_google_guava_guava(**kwargs):

--- a/deps.bzl
+++ b/deps.bzl
@@ -262,8 +262,8 @@ def com_google_protobuf_lite(**kwargs):
     """A different branch of google/protobuf that contains the protobuf_lite plugin
     """
     name = "com_google_protobuf_lite"
-    ref = get_ref(name, "384989534b2246d413dbcd750744faab2607b516", kwargs)
-    sha256 = get_sha256(name, "97b07327b491924fc5173fe1adc2bb504751b0f13990b70b1b5da16eddb47c8d", kwargs)
+    ref = get_ref(name, "d5e9baa5841d501996ddacbba6ad6da1912e8eeb", kwargs)
+    sha256 = get_sha256(name, "c836a2046acb9635e259c3e639dc2ca50d4550d0350f1c98236fb203065e0359", kwargs)
     github_archive(name, "protocolbuffers", "protobuf", ref, sha256)
 
 def gmaven_rules(**kwargs):


### PR DESCRIPTION
This is needed to fix the use of deprecated REPOSITORY_NAME and
PACKAGE_NAME.