### PR TITLE
grpc.js: split generated js compilation

### DIFF
--- a/closure/deps.bzl
+++ b/closure/deps.bzl
@@ -14,12 +14,8 @@ load("//closure:buildozer_http_archive.bzl", "buildozer_http_archive")
 def io_bazel_rules_closure(**kwargs):
     name = "io_bazel_rules_closure"
 
-    # PR#361 - includes closure_js_library.library_level_checks
-    ref = get_ref(name, "e86d8021f22277fe129a572cd019e846243d4531", kwargs)  # PR #361
-    sha256 = get_sha256(name, "481b6b522c2894906380b4b9c008b2c37ab86eeb182229d75bf453db89ed79bc", kwargs)
-
-    # ref = get_ref(name, "50d3dc9e6d27a5577a0f95708466718825d579f4", kwargs) # HEAD April 2019
-    # sha256 = get_sha256(name, "1c05fea22c9630cf1047f25d008780756373a60ddd4d2a6993cf9858279c5da6", kwargs)
+    ref = get_ref(name, "ad75d7cc1cff0e845cd83683881915d995bd75b2", kwargs)
+    sha256 = get_sha256(name, "bdb00831682cd0923df36e19b01619b8230896d582f16304a937d8dc8270b1b6", kwargs)
 
     if "io_bazel_rules_closure" not in native.existing_rules():
         buildozer_http_archive(

--- a/example/github.com/stackb/grpc.js/closure_grpc_compile/WORKSPACE
+++ b/example/github.com/stackb/grpc.js/closure_grpc_compile/WORKSPACE
@@ -8,9 +8,3 @@ local_repository(
 load("@build_stack_rules_proto//github.com/stackb/grpc.js:deps.bzl", "closure_grpc_compile")
 
 closure_grpc_compile()
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()

--- a/example/github.com/stackb/grpc.js/closure_grpc_library/.bazelrc
+++ b/example/github.com/stackb/grpc.js/closure_grpc_library/.bazelrc
@@ -2,3 +2,5 @@
 build --all_incompatible_changes
 # 
 build --incompatible_use_toolchain_resolution_for_java_rules=false
+# 
+build --incompatible_disallow_struct_provider_syntax=false

--- a/example/github.com/stackb/grpc.js/closure_grpc_library/WORKSPACE
+++ b/example/github.com/stackb/grpc.js/closure_grpc_library/WORKSPACE
@@ -11,10 +11,4 @@ closure_grpc_library()
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
 
-closure_repositories(omit_com_google_protobuf = True)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()
+closure_repositories()

--- a/github.com/stackb/grpc.js/README.md
+++ b/github.com/stackb/grpc.js/README.md
@@ -17,12 +17,6 @@ Generates protobuf closure grpc *.js files
 load("@build_stack_rules_proto//github.com/stackb/grpc.js:deps.bzl", "closure_grpc_compile")
 
 closure_grpc_compile()
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()
 ```
 
 ### `BUILD.bazel`
@@ -71,13 +65,7 @@ closure_grpc_library()
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
 
-closure_repositories(omit_com_google_protobuf = True)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()
+closure_repositories()
 ```
 
 ### `BUILD.bazel`
@@ -96,6 +84,7 @@ closure_grpc_library(
 | Category | Flag | Value | Description |
 | --- | --- | --- | --- |
 | build | incompatible_use_toolchain_resolution_for_java_rules | false |  |
+| build | incompatible_disallow_struct_provider_syntax | false |  |
 
 ### Mandatory Attributes
 

--- a/github.com/stackb/grpc.js/closure_grpc_library.bzl
+++ b/github.com/stackb/grpc.js/closure_grpc_library.bzl
@@ -6,36 +6,54 @@ def closure_grpc_library(**kwargs):
     name = kwargs.get("name")
     deps = kwargs.get("deps")
     visibility = kwargs.get("visibility")
+    verbose = kwargs.pop("verbose", 0)
+    transitivity = kwargs.pop("transitivity", {})
+    transitive = kwargs.pop("transitive", True)
+    closure_deps = kwargs.pop("closure_deps", [])
 
     name_pb = name + "_pb"
+    name_pb_lib = name + "_pb_lib"
     name_pb_grpc = name + "_pb_grpc"
 
     closure_proto_compile(
         name = name_pb,
         deps = deps,
         visibility = visibility,
-        verbose = kwargs.pop("verbose", 0),
-        transitivity = kwargs.pop("transitivity", {}),
-        transitive = kwargs.pop("transitive", True),
+        verbose = verbose,
+        transitivity = transitivity,
+        transitive = transitive,
     )
 
     closure_grpc_compile(
         name = name_pb_grpc,
         deps = deps,
         visibility = visibility,
-        verbose = kwargs.pop("verbose", 0),
-        transitivity = kwargs.pop("transitivity", {}),
-        transitive = kwargs.pop("transitive", True),
+        verbose = verbose,
+        transitivity = transitivity,
+        transitive = transitive,
     )
 
-    closure_deps = kwargs.get("closure_deps", [])
+    closure_js_library(
+        name = name_pb_lib,
+        srcs = [name_pb],
+        deps = [
+            "@io_bazel_rules_closure//closure/protobuf:jspb",
+        ] + closure_deps,
+        internal_descriptors = [
+            name_pb + "/descriptor.source.bin",
+        ],
+        suppress = [
+            "JSC_IMPLICITLY_NULLABLE_JSDOC",
+        ],
+        visibility = visibility,
+    )
 
     closure_js_library(
         name = name,
-        srcs = [name_pb, name_pb_grpc],
+        srcs = [name_pb_grpc],
         deps = [
-            "@io_bazel_rules_closure//closure/library",
-            "@io_bazel_rules_closure//closure/protobuf:jspb",
+            name_pb_lib,
+            "@io_bazel_rules_closure//closure/library/promise",
             "@com_github_stackb_grpc_js//js/grpc/stream:observer",
             "@com_github_stackb_grpc_js//js/grpc/stream/observer:call",
             "@com_github_stackb_grpc_js//js/grpc",
@@ -46,9 +64,11 @@ def closure_grpc_library(**kwargs):
             name_pb + "/descriptor.source.bin",
             name_pb_grpc + "/descriptor.source.bin",
         ],
+        exports = [
+            name_pb_lib,
+        ],
         suppress = [
             "JSC_IMPLICITLY_NULLABLE_JSDOC",
         ],
-        library_level_checks = False,
         visibility = visibility,
     )

--- a/github.com/stackb/grpc.js/deps.bzl
+++ b/github.com/stackb/grpc.js/deps.bzl
@@ -1,7 +1,6 @@
 load(
     "//:deps.bzl",
     "com_github_stackb_grpc_js",
-    "io_bazel_rules_go",
 )
 load(
     "//closure:deps.bzl",
@@ -15,7 +14,6 @@ load(
 
 def closure_grpc_compile(**kwargs):
     protobuf(**kwargs)
-    io_bazel_rules_go(**kwargs)
     com_github_stackb_grpc_js(**kwargs)
 
 def closure_grpc_library(**kwargs):

--- a/github.com/stackb/grpc.js/example/routeguide/client/BUILD.bazel
+++ b/github.com/stackb/grpc.js/example/routeguide/client/BUILD.bazel
@@ -36,6 +36,7 @@ closure_js_library(
     ],
     deps = [
         ":routeguide",
+        ":routeguide_pb_lib",
         "@io_bazel_rules_closure//closure/library/promise",
     ],
 )


### PR DESCRIPTION
Previously the sources for both the generated closure and generated grpc closure
were being lumped together into a single closure_js_library rule.  This PR
splits that into two separate closure_js_library (removes the
dependency of grpc.js on the library_level_checks=false feature in
https://github.com/bazelbuild/rules_closure/pull/361).