### PR TITLE
grpc.js: use updated suppression list

### DIFF
--- a/github.com/stackb/grpc.js/closure_grpc_library.bzl
+++ b/github.com/stackb/grpc.js/closure_grpc_library.bzl
@@ -43,7 +43,12 @@ def closure_grpc_library(**kwargs):
             name_pb + "/descriptor.source.bin",
         ],
         suppress = [
+            "JSC_LATE_PROVIDE_ERROR",
+            "JSC_UNDEFINED_VARIABLE",
             "JSC_IMPLICITLY_NULLABLE_JSDOC",
+            "JSC_STRICT_INEXISTENT_PROPERTY",
+            "JSC_POSSIBLE_INEXISTENT_PROPERTY",
+            "JSC_UNRECOGNIZED_TYPE_ERROR",
         ],
         visibility = visibility,
     )

--- a/tools/rulegen/grpcjs.go
+++ b/tools/rulegen/grpcjs.go
@@ -57,7 +57,12 @@ def {{ .Rule.Name }}(**kwargs):
             name_pb + "/descriptor.source.bin",
         ],
         suppress = [
+            "JSC_LATE_PROVIDE_ERROR",
+            "JSC_UNDEFINED_VARIABLE",
             "JSC_IMPLICITLY_NULLABLE_JSDOC",
+            "JSC_STRICT_INEXISTENT_PROPERTY",
+            "JSC_POSSIBLE_INEXISTENT_PROPERTY",
+            "JSC_UNRECOGNIZED_TYPE_ERROR",
         ],
         visibility = visibility,
     )


### PR DESCRIPTION
In closure.go the generated rules that call a closure_js_library on generated
protobuf contain a "standard" list of suppress values.  This PR copies those
over to to grpcjs.go.

Fixes #80