### PR TITLE
java/scala: remove usage of maven_jar.

### DIFF
--- a/android/deps.bzl
+++ b/android/deps.bzl
@@ -1,7 +1,8 @@
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
+
 load(
     "//:deps.bzl",
     "build_bazel_rules_android",
-    "com_google_guava_guava_android",
     "com_google_protobuf",
     "com_google_protobuf_lite",
     "io_grpc_grpc_java",
@@ -10,6 +11,15 @@ load(
     "//protobuf:deps.bzl",
     "protobuf",
 )
+
+def com_google_guava_guava_android(**kwargs):
+    if "com_google_guava_guava_android" not in native.existing_rules():
+        jvm_maven_import_external(
+            name = "com_google_guava_guava_android",
+            artifact = "com.google.guava:guava:27.0.1-android",
+            server_urls = ["http://central.maven.org/maven2"],
+            artifact_sha256 = "caf0955aed29a1e6d149f85cfb625a89161b5cf88e0e246552b7ffa358204e28",
+        )
 
 def android_proto_compile(**kwargs):
     protobuf(**kwargs)

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,5 +1,4 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-# load("@bazel_tools//tools/build_defs/repo:maven_rules.bzl", "maven_jar")
 
 # https://raw.githubusercontent.com/grpc/grpc/master/third_party/zlib.BUILD
 ZLIB_BUILD = """
@@ -59,16 +58,6 @@ def github_archive(name, org, repo, ref, sha256):
                 "https://github.com/%s/%s/archive/%s.tar.gz" % (org, repo, ref),
             ],
             sha256 = sha256,
-        )
-
-def jar(name, artifact, sha1):
-    """Declare a maven_jar
-    """
-    if name not in native.existing_rules():
-        native.maven_jar(
-            name = name,
-            artifact = artifact,
-            sha1 = sha1,
         )
 
 def get_ref(name, default, kwargs):
@@ -339,53 +328,6 @@ def io_grpc_grpc_java(**kwargs):
     sha256 = get_sha256(name, "1eeb136874a58a0a311a0701016aced96919f501ced0372013eb1708724ab046", kwargs)
     github_archive(name, "grpc", "grpc-java", ref, sha256)
 
-def com_google_guava_guava(**kwargs):
-    """grpc java plugin and jars
-    """
-    name = "com_google_guava_guava"
-    artifact = get_artifact(name, "com.google.guava:guava:20.0", kwargs)
-    sha1 = get_sha1(name, "89507701249388e1ed5ddcf8c41f4ce1be7831ef", kwargs)
-    jar(name, artifact, sha1)
-
-def com_google_guava_guava_android(**kwargs):
-    """android-specific guava 
-    """
-    name = "com_google_guava_guava_android"
-    artifact = get_artifact(name, "com.google.guava:guava:27.0.1-android", kwargs)
-    sha1 = get_sha1(name, "b7e1c37f66ef193796ccd7ea6e80c2b05426182d", kwargs)
-    jar(name, artifact, sha1)
-
-def com_thesamet_scalapb_scalapb_json4s(**kwargs):
-    """json parsing library for scala
-    """
-    name = "com_thesamet_scalapb_scalapb_json4s"
-    artifact = get_artifact(name, "com.thesamet.scalapb:scalapb-json4s_2.12:0.7.1", kwargs)
-    sha1 = get_sha1(name, "808eeb6cfaa359a6c6a3dd2ea2c0374caee30c28", kwargs)
-    jar(name, artifact, sha1)
-
-def org_json4s_json4s_jackson_2_12(**kwargs):
-    """json parsing library for scala
-    """
-    name = "org_json4s_json4s_jackson_2_12"
-    artifact = get_artifact(name, "org.json4s:json4s-jackson_2.12:3.6.1", kwargs)
-    sha1 = get_sha1(name, "864cf214dcd5686929f1c7f8d61344195c828b35", kwargs)
-    jar(name, artifact, sha1)
-
-def org_json4s_json4s_core_2_12(**kwargs):
-    """json parsing library for scala - core
-    """
-    name = "org_json4s_json4s_core_2_12"
-    artifact = get_artifact(name, "org.json4s:json4s-core_2.12:3.6.1", kwargs)
-    sha1 = get_sha1(name, "7a619365089281c6015b80c499ff3b3cb196572f", kwargs)
-    jar(name, artifact, sha1)
-
-def org_json4s_json4s_ast_2_12(**kwargs):
-    """json parsing library for scala
-    """
-    name = "org_json4s_json4s_ast_2_12"
-    artifact = get_artifact(name, "org.json4s:json4s-ast_2.12:3.6.1", kwargs)
-    sha1 = get_sha1(name, "cf937592788dfa654acb9679b97eb1e691bf69f8", kwargs)
-    jar(name, artifact, sha1)
 
 def com_github_scalapb_scalapb(**kwargs):
     """scala compiler plugin

--- a/java/deps.bzl
+++ b/java/deps.bzl
@@ -1,14 +1,26 @@
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
+
 load(
     "//:deps.bzl",
-    "com_google_guava_guava",
     "com_google_protobuf",
     "io_grpc_grpc_java",
 )
+
 load(
     "//protobuf:deps.bzl",
     "protobuf",
 )
+
+def com_google_guava_guava(**kwargs):
+    if "com_google_guava_guava" not in native.existing_rules():
+        jvm_maven_import_external(
+            name = "com_google_guava_guava",
+            artifact = "com.google.guava:guava:20.0",
+            server_urls = ["http://central.maven.org/maven2"],
+            artifact_sha256 = "36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8",
+            licenses = ["reciprocal"],  # CDDL License
+        )
+
 
 # From https://github.com/grpc/grpc-java/blob/master/repositories.bzl
 def javax_annotation_javax_annotation_api(**kwargs):

--- a/scala/deps.bzl
+++ b/scala/deps.bzl
@@ -1,17 +1,52 @@
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
+
 load(
     "//:deps.bzl",
     "com_github_scalapb_scalapb",
-    "com_thesamet_scalapb_scalapb_json4s",
     "io_bazel_rules_go",
     "io_bazel_rules_scala",
-    "org_json4s_json4s_ast_2_12",
-    "org_json4s_json4s_core_2_12",
-    "org_json4s_json4s_jackson_2_12",
 )
+
 load(
     "//protobuf:deps.bzl",
     "protobuf",
 )
+
+def com_thesamet_scalapb_scalapb_json4s(**kwargs):
+    if "com_thesamet_scalapb_scalapb_json4s" not in native.existing_rules():
+        jvm_maven_import_external(
+            name = "com_thesamet_scalapb_scalapb_json4s",
+            artifact = "com.thesamet.scalapb:scalapb-json4s_2.12:0.7.1",
+            server_urls = ["http://central.maven.org/maven2"],
+            artifact_sha256 = "6c8771714329464e03104b6851bfdc3e2e4967276e1a9bd2c87c3b5a6d9c53c7",
+        )
+
+def org_json4s_json4s_jackson_2_12(**kwargs):
+    if "org_json4s_json4s_jackson_2_12" not in native.existing_rules():
+        jvm_maven_import_external(
+            name = "org_json4s_json4s_jackson_2_12",
+            artifact = "org.json4s:json4s-jackson_2.12:3.6.1",
+            server_urls = ["http://central.maven.org/maven2"],
+            artifact_sha256 = "83b854a39e69f022ad3d7dd3da664623252dc822ed4ed1117304f39115c88043",
+        )
+
+def org_json4s_json4s_core_2_12(**kwargs):
+    if "org_json4s_json4s_core_2_12" not in native.existing_rules():
+        jvm_maven_import_external(
+            name = "org_json4s_json4s_core_2_12",
+            artifact = "org.json4s:json4s-core_2.12:3.6.1",
+            server_urls = ["http://central.maven.org/maven2"],
+            artifact_sha256 = "e0f481509429a24e295b30ba64f567bad95e8d978d0882ec74e6dab291fcdac0",
+        )
+
+def org_json4s_json4s_ast_2_12(**kwargs):
+    if "org_json4s_json4s_ast_2_12" not in native.existing_rules():
+        jvm_maven_import_external(
+            name = "org_json4s_json4s_ast_2_12",
+            artifact = "org.json4s:json4s-ast_2.12:3.6.1",
+            server_urls = ["http://central.maven.org/maven2"],
+            artifact_sha256 = "39c7de601df28e32eb0c4e3d684ec65bbf2e59af83c6088cda12688d796f7746",
+        )
 
 def scala_proto_compile(**kwargs):
     protobuf(**kwargs)


### PR DESCRIPTION
This CL removes usage of maven_jar and uses the recommended
jvm_maven_import_external rule instead.  It also moves dependencies closer to
their usage.

See https://groups.google.com/forum/#!topic/bazel-discuss/6iGccyO9X_E