### PR TITLE
Fix runfiles error with python_binary plugin tool

### DIFF
--- a/aspect.bzl
+++ b/aspect.bzl
@@ -301,25 +301,18 @@ def proto_compile_aspect_impl(target, ctx):
     tools = [protoc] + plugin_tools.values()
 
     # SAME
-    if verbose > 0:
-        print("%s: %s" % (mnemonic, command))
-    if verbose > 1:
-        command += " && echo '\n##### SANDBOX AFTER RUNNING PROTOC' && find . -type f "
-    if verbose > 2:
-        command = "echo '\n##### SANDBOX BEFORE RUNNING PROTOC' && find . -type l && " + command
     if verbose > 3:
-        command = "env && " + command
         for f in outputs:
             print("EXPECTED OUTPUT:", f.path)
         print("INPUTS:", inputs)
         print("TOOLS:", tools)
-        print("COMMAND:", command)
         for arg in args:
             print("ARG:", arg)
 
     ctx.actions.run_shell(
         mnemonic = mnemonic,  # SAME
-        command = command,  # SAME
+        executable=protoc,  # SAME
+        arguments = args,
 
         # This is different!
         inputs = inputs,

--- a/compile.bzl
+++ b/compile.bzl
@@ -362,32 +362,6 @@ def get_plugin_outputs(ctx, descriptor, outputs, src, proto, plugin):
         outputs.append(ctx.actions.declare_file(filename, sibling = sibling))
     return outputs
 
-def get_plugin_runfiles(tool):
-    """Gather runfiles for a plugin.
-    """
-    files = []
-    if not tool:
-        return files
-
-    info = tool[DefaultInfo]
-    if not info:
-        return files
-
-    if info.files:
-        files += info.files.to_list()
-
-    if info.default_runfiles:
-        runfiles = info.default_runfiles
-        if runfiles.files:
-            files += runfiles.files.to_list()
-
-    if info.data_runfiles:
-        runfiles = info.data_runfiles
-        if runfiles.files:
-            files += runfiles.files.to_list()
-
-    return files
-
 def proto_compile_impl(ctx):
     ###
     ### Part 1: setup variables used in scope
@@ -463,7 +437,7 @@ def proto_compile_impl(ctx):
     for plugin in plugins:
         if plugin.executable:
             plugin_tools[plugin.name] = plugin.executable
-        data += plugin.data + get_plugin_runfiles(plugin.tool)
+        data += plugin.data
 
         filename = _get_plugin_out(ctx, plugin)
         if not filename:
@@ -563,10 +537,10 @@ def proto_compile_impl(ctx):
         executable=protoc,
         arguments = args,
         mnemonic = mnemonic,
-        command = command,
-        inputs = protos + data,
+        inputs = protos + data + resolved_inputs.to_list(),
         outputs = outputs + [descriptor] + ctx.outputs.outputs,
         tools = [protoc] + plugin_tools.values(),
+        input_manifests = input_manifests
     )
 
     ###

--- a/compile.bzl
+++ b/compile.bzl
@@ -553,20 +553,15 @@ def proto_compile_impl(ctx):
 
     mnemonic = "ProtoCompile"
 
-    command = " ".join([protoc.path] + args)
-
-    if verbose > 0:
-        print("%s: %s" % (mnemonic, command))
-    if verbose > 1:
-        command += " && echo '\n##### SANDBOX AFTER RUNNING PROTOC' && find ."
-    if verbose > 2:
-        command = "echo '\n##### SANDBOX BEFORE RUNNING PROTOC' && find . && " + command
     if verbose > 3:
-        command = "env && " + command
         for f in outputs:
             print("expected output: %q", f.path)
 
-    ctx.actions.run_shell(
+    resolved_inputs, input_manifests = ctx.resolve_tools(tools=[plugin.executable_target for plugin in plugins if plugin.executable])
+
+    ctx.actions.run(
+        executable=protoc,
+        arguments = args,
         mnemonic = mnemonic,
         command = command,
         inputs = protos + data,

--- a/plugin.bzl
+++ b/plugin.bzl
@@ -8,12 +8,14 @@ ProtoPluginInfo = provider(fields = {
     "outdir": "whether to use the package output dir",
     "data": "additional data",
     "transitivity": "transitivity properties",
+    "executable_target": "plugin tool target",
 })
 
 def _proto_plugin_impl(ctx):
     return [ProtoPluginInfo(
         data = ctx.files.data,
         executable = ctx.executable.tool,
+        executable_target = ctx.attr.tool,
         name = ctx.label.name,
         options = ctx.attr.options,
         out = ctx.attr.out,


### PR DESCRIPTION
That was caused from the way we resolved runfiles (get_plugin_runfiles), sometimes it wasn't working. 