### PR TITLE
python: fix checksum error for six-1.12.0.tar.gz

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -284,7 +284,7 @@ py_library(
   visibility = ["//visibility:public"],
 )
         """,
-            sha256 = "105f8d68613f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+            sha256 = "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73",
             urls = ["https://pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz"],
         )
 


### PR DESCRIPTION
The package six-1.12.0 couldn't be downloaded because the checksum in deps.bzl was wrong.

Here is the error message I got.
`no such package '@six//': java.io.IOException: Error downloading [https://pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz] to /private/var/tmp/_bazel_xxxxxx/f913538d281668dcc71ea43c01d534fc/external/six/six-1.12.0.tar.gz: Checksum was d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 but wanted 105f8d68613f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a`