### PR TITLE
Be compatible with incompatible_restrict_named_params

### DIFF
--- a/example/routeguide/routeguide_test.bzl
+++ b/example/routeguide/routeguide_test.bzl
@@ -85,7 +85,7 @@ routeguide_test = rule(
 def get_parent_dirname(label):
     if label.startswith("//"):
         label = label[2:]
-    segments = label.split(sep = "/", maxsplit = 2)
+    segments = label.split("/", 2)
     return segments[0]
 
 def routeguide_test_matrix(


### PR DESCRIPTION
This was enabled in bazel 0.26.0