### PR TITLE
Update rules_go for bazel 0.27 compatibility.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,3 +20,4 @@ build --incompatible_remove_native_maven_jar=false
 build --incompatible_allow_python_version_transitions=false
 build --incompatible_py3_is_default=false # grpc-python does not work with python3?
 build --incompatible_disallow_empty_glob=false
+build --incompatible_tls_enabled_removed=false

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,3 +19,4 @@ build --incompatible_use_toolchain_resolution_for_java_rules=false
 build --incompatible_remove_native_maven_jar=false
 build --incompatible_allow_python_version_transitions=false
 build --incompatible_py3_is_default=false # grpc-python does not work with python3?
+build --incompatible_disallow_empty_glob=false

--- a/deps.bzl
+++ b/deps.bzl
@@ -252,8 +252,8 @@ def io_bazel_rules_go(**kwargs):
     """Go Rules
     """
     name = "io_bazel_rules_go"
-    ref = get_ref(name, "4fec67d1fcefe7c80d6f4cc2ae0841c9d90e429a", kwargs)  # post-18.3
-    sha256 = get_sha256(name, "2ab9320c583b05b805a7f8f4005fd081606505a64308051008d32148d7f98e1f", kwargs)
+    ref = get_ref(name, "fabf03c1cd31bcf15fb945d932cef322b242be3a", kwargs)  # post-18.6
+    sha256 = get_sha256(name, "d40144fcb282e167a1836c4d1a9aabdd457051717a4648153a89aa34bd9f8e6a", kwargs)
     github_archive(name, "bazelbuild", "rules_go", ref, sha256)
 
 def io_bazel_rules_python(**kwargs):


### PR DESCRIPTION
There is also an issue with incompatible_disallow_empty_glob in 0.27 so disabled it: https://github.com/bazelbuild/bazel/issues/8517 For tls_enabled see https://github.com/bazelbuild/bazel/issues/8061