### PR TITLE
Update paths to grpc plugins

### DIFF
--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -19,6 +19,6 @@ proto_plugin(
         "{basename}.grpc.pb.cc",
         "{basename}_mock.grpc.pb.h",
     ],
-    tool = "@com_github_grpc_grpc//:grpc_cpp_plugin",
+    tool = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
     visibility = ["//visibility:public"],
 )

--- a/csharp/BUILD.bazel
+++ b/csharp/BUILD.bazel
@@ -12,7 +12,7 @@ proto_plugin(
 proto_plugin(
     name = "grpc_csharp",
     outputs = ["{package}/{basename|pascal}Grpc.cs"],
-    tool = "@com_github_grpc_grpc//:grpc_csharp_plugin",
+    tool = "@com_github_grpc_grpc//src/compiler:grpc_csharp_plugin",
     transitivity = {
         "google/protobuf": "exclude",
     },

--- a/node/BUILD.bazel
+++ b/node/BUILD.bazel
@@ -13,6 +13,6 @@ proto_plugin(
 proto_plugin(
     name = "grpc_js",
     outputs = ["_grpc_pb.js"],
-    tool = "@com_github_grpc_grpc//:grpc_node_plugin",
+    tool = "@com_github_grpc_grpc//src/compiler:grpc_node_plugin",
     visibility = ["//visibility:public"],
 )

--- a/objc/BUILD.bazel
+++ b/objc/BUILD.bazel
@@ -15,6 +15,6 @@ proto_plugin(
         "{basename|pascal|objc}.pbrpc.h",
         "{basename|pascal|objc}.pbrpc.m",
     ],
-    tool = "@com_github_grpc_grpc//:grpc_objective_c_plugin",
+    tool = "@com_github_grpc_grpc//src/compiler:grpc_objective_c_plugin",
     visibility = ["//visibility:public"],
 )

--- a/php/BUILD.bazel
+++ b/php/BUILD.bazel
@@ -13,6 +13,6 @@ proto_plugin(
     # Even though this is php, aggregate into a jar so we don't have to predict
     # the outputs
     out = "{name}.jar",
-    tool = "@com_github_grpc_grpc//:grpc_php_plugin",
+    tool = "@com_github_grpc_grpc//src/compiler:grpc_php_plugin",
     visibility = ["//visibility:public"],
 )

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -9,7 +9,7 @@ proto_plugin(
 proto_plugin(
     name = "grpc_python",
     outputs = ["_pb2_grpc.py"],
-    tool = "@com_github_grpc_grpc//:grpc_python_plugin",
+    tool = "@com_github_grpc_grpc//src/compiler:grpc_python_plugin",
     transitivity = {
         "google/protobuf": "exclude",
     },

--- a/ruby/BUILD.bazel
+++ b/ruby/BUILD.bazel
@@ -9,6 +9,6 @@ proto_plugin(
 proto_plugin(
     name = "grpc_ruby",
     outputs = ["{basename}_services_pb.rb"],
-    tool = "@com_github_grpc_grpc//:grpc_ruby_plugin",
+    tool = "@com_github_grpc_grpc//src/compiler:grpc_ruby_plugin",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
gRPC changed the paths of the plugins from //:\*_plugin to //src/compiler:\*_plugin.

This should fix issue #108 