### PR TITLE
Fix broken build: Update links to central.maven.org to use HTTPS

### DIFF
--- a/android/deps.bzl
+++ b/android/deps.bzl
@@ -17,7 +17,7 @@ def com_google_guava_guava_android(**kwargs):
         jvm_maven_import_external(
             name = "com_google_guava_guava_android",
             artifact = "com.google.guava:guava:27.0.1-android",
-            server_urls = ["http://central.maven.org/maven2"],
+            server_urls = ["https://central.maven.org/maven2"],
             artifact_sha256 = "caf0955aed29a1e6d149f85cfb625a89161b5cf88e0e246552b7ffa358204e28",
         )
 

--- a/java/deps.bzl
+++ b/java/deps.bzl
@@ -16,7 +16,7 @@ def com_google_guava_guava(**kwargs):
         jvm_maven_import_external(
             name = "com_google_guava_guava",
             artifact = "com.google.guava:guava:20.0",
-            server_urls = ["http://central.maven.org/maven2"],
+            server_urls = ["https://central.maven.org/maven2"],
             artifact_sha256 = "36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8",
             licenses = ["reciprocal"],  # CDDL License
         )
@@ -29,7 +29,7 @@ def javax_annotation_javax_annotation_api(**kwargs):
         jvm_maven_import_external(
             name = "javax_annotation_javax_annotation_api",
             artifact = "javax.annotation:javax.annotation-api:1.2",
-            server_urls = ["http://central.maven.org/maven2"],
+            server_urls = ["https://central.maven.org/maven2"],
             artifact_sha256 = "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
             licenses = ["reciprocal"],  # CDDL License
         )
@@ -41,7 +41,7 @@ def com_google_errorprone_error_prone_annotations(**kwargs):
         jvm_maven_import_external(
             name = "com_google_errorprone_error_prone_annotations",
             artifact = "com.google.errorprone:error_prone_annotations:2.3.2",
-            server_urls = ["http://central.maven.org/maven2"],
+            server_urls = ["https://central.maven.org/maven2"],
             artifact_sha256 = "357cd6cfb067c969226c442451502aee13800a24e950fdfde77bcdb4565a668d",
             licenses = ["notice"],  # Apache 2.0
         )

--- a/scala/deps.bzl
+++ b/scala/deps.bzl
@@ -17,7 +17,7 @@ def com_thesamet_scalapb_scalapb_json4s(**kwargs):
         jvm_maven_import_external(
             name = "com_thesamet_scalapb_scalapb_json4s",
             artifact = "com.thesamet.scalapb:scalapb-json4s_2.12:0.7.1",
-            server_urls = ["http://central.maven.org/maven2"],
+            server_urls = ["https://central.maven.org/maven2"],
             artifact_sha256 = "6c8771714329464e03104b6851bfdc3e2e4967276e1a9bd2c87c3b5a6d9c53c7",
         )
 
@@ -26,7 +26,7 @@ def org_json4s_json4s_jackson_2_12(**kwargs):
         jvm_maven_import_external(
             name = "org_json4s_json4s_jackson_2_12",
             artifact = "org.json4s:json4s-jackson_2.12:3.6.1",
-            server_urls = ["http://central.maven.org/maven2"],
+            server_urls = ["https://central.maven.org/maven2"],
             artifact_sha256 = "83b854a39e69f022ad3d7dd3da664623252dc822ed4ed1117304f39115c88043",
         )
 
@@ -35,7 +35,7 @@ def org_json4s_json4s_core_2_12(**kwargs):
         jvm_maven_import_external(
             name = "org_json4s_json4s_core_2_12",
             artifact = "org.json4s:json4s-core_2.12:3.6.1",
-            server_urls = ["http://central.maven.org/maven2"],
+            server_urls = ["https://central.maven.org/maven2"],
             artifact_sha256 = "e0f481509429a24e295b30ba64f567bad95e8d978d0882ec74e6dab291fcdac0",
         )
 
@@ -44,7 +44,7 @@ def org_json4s_json4s_ast_2_12(**kwargs):
         jvm_maven_import_external(
             name = "org_json4s_json4s_ast_2_12",
             artifact = "org.json4s:json4s-ast_2.12:3.6.1",
-            server_urls = ["http://central.maven.org/maven2"],
+            server_urls = ["https://central.maven.org/maven2"],
             artifact_sha256 = "39c7de601df28e32eb0c4e3d684ec65bbf2e59af83c6088cda12688d796f7746",
         )
 


### PR DESCRIPTION
Maven Central has recently disallowed HTTP traffic. As a consequence, we are now unable to build because the artifacts cannot be retrieved.

In this PR, we solve the problem by updating every Maven Central URLs to use HTTPS.