### PR TITLE
Centralize maven urls & move from central.maven.org -> repo1.maven.org

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -364,6 +364,8 @@ rules_jvm_external()
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
+load("//:deps.bzl", "MAVEN_SERVER_URLS")
+
 maven_install(
     name = "maven_android",
     artifacts = [
@@ -372,10 +374,7 @@ maven_install(
     # Fail if a checksum file for the artifact is missing in the repository.
     # Falls through "SHA-1" and "MD5". Defaults to True.
     fail_on_missing_checksum = False,
-    repositories = [
-        "https://maven.google.com",
-        "https://repo1.maven.org/maven2",
-    ],
+    repositories = MAVEN_SERVER_URLS,
 )
 
 load("@build_stack_rules_proto//android:deps.bzl", "android_grpc_library")

--- a/android/deps.bzl
+++ b/android/deps.bzl
@@ -6,6 +6,7 @@ load(
     "com_google_protobuf",
     "com_google_protobuf_lite",
     "io_grpc_grpc_java",
+    "MAVEN_SERVER_URLS",
 )
 load(
     "//protobuf:deps.bzl",
@@ -17,7 +18,7 @@ def com_google_guava_guava_android(**kwargs):
         jvm_maven_import_external(
             name = "com_google_guava_guava_android",
             artifact = "com.google.guava:guava:27.0.1-android",
-            server_urls = ["https://central.maven.org/maven2"],
+            server_urls = MAVEN_SERVER_URLS,
             artifact_sha256 = "caf0955aed29a1e6d149f85cfb625a89161b5cf88e0e246552b7ffa358204e28",
         )
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,5 +1,10 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+MAVEN_SERVER_URLS = [
+     "https://maven.google.com",
+     "https://repo1.maven.org/maven2",
+ ]
+
 # https://raw.githubusercontent.com/grpc/grpc/master/third_party/zlib.BUILD
 ZLIB_BUILD = """
 cc_library(

--- a/java/deps.bzl
+++ b/java/deps.bzl
@@ -4,6 +4,7 @@ load(
     "//:deps.bzl",
     "com_google_protobuf",
     "io_grpc_grpc_java",
+    "MAVEN_SERVER_URLS",
 )
 
 load(
@@ -16,7 +17,7 @@ def com_google_guava_guava(**kwargs):
         jvm_maven_import_external(
             name = "com_google_guava_guava",
             artifact = "com.google.guava:guava:20.0",
-            server_urls = ["https://central.maven.org/maven2"],
+            server_urls = MAVEN_SERVER_URLS,
             artifact_sha256 = "36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8",
             licenses = ["reciprocal"],  # CDDL License
         )
@@ -29,7 +30,7 @@ def javax_annotation_javax_annotation_api(**kwargs):
         jvm_maven_import_external(
             name = "javax_annotation_javax_annotation_api",
             artifact = "javax.annotation:javax.annotation-api:1.2",
-            server_urls = ["https://central.maven.org/maven2"],
+            server_urls = MAVEN_SERVER_URLS,
             artifact_sha256 = "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
             licenses = ["reciprocal"],  # CDDL License
         )
@@ -41,7 +42,7 @@ def com_google_errorprone_error_prone_annotations(**kwargs):
         jvm_maven_import_external(
             name = "com_google_errorprone_error_prone_annotations",
             artifact = "com.google.errorprone:error_prone_annotations:2.3.2",
-            server_urls = ["https://central.maven.org/maven2"],
+            server_urls = MAVEN_SERVER_URLS,
             artifact_sha256 = "357cd6cfb067c969226c442451502aee13800a24e950fdfde77bcdb4565a668d",
             licenses = ["notice"],  # Apache 2.0
         )

--- a/scala/deps.bzl
+++ b/scala/deps.bzl
@@ -5,6 +5,7 @@ load(
     "com_github_scalapb_scalapb",
     "io_bazel_rules_go",
     "io_bazel_rules_scala",
+    "MAVEN_SERVER_URLS",
 )
 
 load(
@@ -17,7 +18,7 @@ def com_thesamet_scalapb_scalapb_json4s(**kwargs):
         jvm_maven_import_external(
             name = "com_thesamet_scalapb_scalapb_json4s",
             artifact = "com.thesamet.scalapb:scalapb-json4s_2.12:0.7.1",
-            server_urls = ["https://central.maven.org/maven2"],
+            server_urls = MAVEN_SERVER_URLS,
             artifact_sha256 = "6c8771714329464e03104b6851bfdc3e2e4967276e1a9bd2c87c3b5a6d9c53c7",
         )
 
@@ -26,7 +27,7 @@ def org_json4s_json4s_jackson_2_12(**kwargs):
         jvm_maven_import_external(
             name = "org_json4s_json4s_jackson_2_12",
             artifact = "org.json4s:json4s-jackson_2.12:3.6.1",
-            server_urls = ["https://central.maven.org/maven2"],
+            server_urls = MAVEN_SERVER_URLS,
             artifact_sha256 = "83b854a39e69f022ad3d7dd3da664623252dc822ed4ed1117304f39115c88043",
         )
 
@@ -35,7 +36,7 @@ def org_json4s_json4s_core_2_12(**kwargs):
         jvm_maven_import_external(
             name = "org_json4s_json4s_core_2_12",
             artifact = "org.json4s:json4s-core_2.12:3.6.1",
-            server_urls = ["https://central.maven.org/maven2"],
+            server_urls = MAVEN_SERVER_URLS,
             artifact_sha256 = "e0f481509429a24e295b30ba64f567bad95e8d978d0882ec74e6dab291fcdac0",
         )
 
@@ -44,7 +45,7 @@ def org_json4s_json4s_ast_2_12(**kwargs):
         jvm_maven_import_external(
             name = "org_json4s_json4s_ast_2_12",
             artifact = "org.json4s:json4s-ast_2.12:3.6.1",
-            server_urls = ["https://central.maven.org/maven2"],
+            server_urls = MAVEN_SERVER_URLS,
             artifact_sha256 = "39c7de601df28e32eb0c4e3d684ec65bbf2e59af83c6088cda12688d796f7746",
         )
 


### PR DESCRIPTION
https://central.maven.org doesn't resolve anymore. The rules_scala project had to do a similar move this month. https://github.com/bazelbuild/rules_scala/commit/a676633dc14d8239569affb2acafbef255df3480#diff-09498dbadf45966909850dc8a47ebb13