### PR TITLE
Allow additional deps in gateway_grpc_library

### DIFF
--- a/github.com/grpc-ecosystem/grpc-gateway/gateway_grpc_library.bzl
+++ b/github.com/grpc-ecosystem/grpc-gateway/gateway_grpc_library.bzl
@@ -20,6 +20,6 @@ def gateway_grpc_library(**kwargs):
         compilers = compilers,
         importpath = importpath,
         proto = deps[0],
-        deps = ["@go_googleapis//google/api:annotations_go_proto"],
+        deps = ["@go_googleapis//google/api:annotations_go_proto"] + deps[1:],
         visibility = visibility,
     )


### PR DESCRIPTION
This is useful when the main proto depends on additional protos, such as:
 "@go_googleapis//google/api:httpbody_proto",
 "@go_googleapis//google/rpc:status_proto",