### PR TITLE
Make the ScalaPB dependency external

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -349,12 +349,16 @@ java_import(
     jars = ["com.thesamet.scalapb.compilerplugin-0.8.0.jar"],
     visibility = ["//visibility:public"],
 )
-java_import(
-    name = "scala-library",
-    jars = ["org.scala-lang.scala-library-2.11.12.jar"],
-    visibility = ["//visibility:public"],
-)
             """,
+        )
+
+def external_scalapb(**kwargs):
+    com_github_scalapb_scalapb(**kwargs)
+    compilerplugin_name = "com_github_scalapb_scalapb_compilerplugin"
+    if compilerplugin_name not in native.existing_rules():
+        native.bind(
+            name = compilerplugin_name,
+            actual = "@com_github_scalapb_scalapb//:compilerplugin"
         )
 
 def com_github_stackb_grpc_js(**kwargs):

--- a/scala/BUILD.bazel
+++ b/scala/BUILD.bazel
@@ -68,11 +68,8 @@ scala_binary(
     srcs = ["CompilerPlugin.scala"],
     main_class = "CompilerPlugin",
     visibility = ["//visibility:public"],
-    runtime_deps = [
-        "@com_github_scalapb_scalapb//:scala-library",
-    ],
     deps = [
-        "@com_github_scalapb_scalapb//:compilerplugin",
+        "//external:com_github_scalapb_scalapb_compilerplugin",
         "@com_google_protobuf//:protobuf_java",
     ],
 )

--- a/scala/deps.bzl
+++ b/scala/deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 
 load(
     "//:deps.bzl",
-    "com_github_scalapb_scalapb",
+    "external_scalapb",
     "io_bazel_rules_go",
     "io_bazel_rules_scala",
     "MAVEN_SERVER_URLS",
@@ -53,7 +53,7 @@ def scala_proto_compile(**kwargs):
     protobuf(**kwargs)
     io_bazel_rules_go(**kwargs)
     io_bazel_rules_scala(**kwargs)
-    com_github_scalapb_scalapb(**kwargs)
+    external_scalapb(**kwargs)
 
 def scala_grpc_compile(**kwargs):
     scala_proto_compile(**kwargs)


### PR DESCRIPTION
Hi!

We're trying to use the `scala_proto_compile` rule to support use-cases currently unsupported by scala_proto_library. We're using a toolchain to select our Scala version, and are unable to use this package since it only supports 2.11. 

I'd like to change the usage of this package to a bind, similar to other dependencies, so that we can override it internally.