### PR TITLE
change single_file to allow_single_file

### DIFF
--- a/example/routeguide/routeguide_test.bzl
+++ b/example/routeguide/routeguide_test.bzl
@@ -68,7 +68,7 @@ routeguide_test = rule(
         "database": attr.label(
             doc = "Path to the feature database json file",
             mandatory = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "data": attr.label_list(
             doc = "Additional data files",


### PR DESCRIPTION
'single_file' is no longer supported. use allow_single_file instead. You can use --incompatible_disable_deprecated_attr_params=false to temporarily disable this check.