### PR TITLE
Remove ProtocConfiguration.Imports

### DIFF
--- a/pkg/plugin/builtin/python_plugin.go
+++ b/pkg/plugin/builtin/python_plugin.go
@@ -29,11 +29,6 @@ func (p *PythonPlugin) Configure(ctx *protoc.PluginContext) *protoc.PluginConfig
 			protoc.Always,
 			ctx.ProtoLibrary.Files()...,
 		),
-		Imports: protoc.FlatMapFiles(
-			pyImports(),
-			protoc.Always,
-			ctx.ProtoLibrary.Files()...,
-		),
 	}
 }
 
@@ -48,32 +43,4 @@ func pythonGeneratedFileName(reldir string) func(f *protoc.File) []string {
 		}
 		return []string{name + "_pb2.py"}
 	}
-}
-
-// pyImports is a utility function that returns a function that
-// computes the name of a predicted imports for a given proto file.
-func pyImports() func(f *protoc.File) []string {
-	return func(f *protoc.File) []string {
-		imports := make([]string, 0)
-
-		pkg := f.Name + "_pb"
-		if f.Package().Name != "" {
-			pkg = f.Package().Name + "." + pkg
-		}
-		for _, m := range f.Messages() {
-			imports = append(imports, getPythonImportName(pkg, m.Name))
-		}
-		for _, e := range f.Enums() {
-			imports = append(imports, getPythonImportName(pkg, e.Name))
-		}
-
-		return imports
-	}
-}
-
-func getPythonImportName(pkg, name string) string {
-	if pkg == "" {
-		return name
-	}
-	return pkg + "." + name
 }

--- a/pkg/plugin/grpc/grpc/protoc-gen-grpc-python.go
+++ b/pkg/plugin/grpc/grpc/protoc-gen-grpc-python.go
@@ -33,11 +33,6 @@ func (p *ProtocGenGrpcPython) Configure(ctx *protoc.PluginContext) *protoc.Plugi
 			protoc.HasService,
 			ctx.ProtoLibrary.Files()...,
 		),
-		Imports: protoc.FlatMapFiles(
-			grpcImports(),
-			protoc.HasService,
-			ctx.ProtoLibrary.Files()...,
-		),
 	}
 }
 
@@ -52,28 +47,4 @@ func grpcGeneratedFileName(reldir string) func(f *protoc.File) []string {
 		}
 		return []string{name + "_pb2_grpc.py"}
 	}
-}
-
-// grpcImports is a utility function that returns a function that
-// computes the name of a predicted imports for a given proto file.
-func grpcImports() func(f *protoc.File) []string {
-	return func(f *protoc.File) []string {
-		imports := make([]string, 0)
-
-		pkg := f.Name + "_grpc_pb"
-		if f.Package().Name != "" {
-			pkg = f.Package().Name + "." + pkg
-		}
-		for _, m := range f.Services() {
-			imports = append(imports, getPythonImportName(pkg, m.Name))
-		}
-		return imports
-	}
-}
-
-func getPythonImportName(pkg, name string) string {
-	if pkg == "" {
-		return name
-	}
-	return pkg + "." + name
 }

--- a/pkg/plugin/grpc/grpcnode/protoc-gen-grpc-node.go
+++ b/pkg/plugin/grpc/grpcnode/protoc-gen-grpc-node.go
@@ -33,11 +33,6 @@ func (p *ProtocGenGrpcNode) Configure(ctx *protoc.PluginContext) *protoc.PluginC
 			protoc.HasService,
 			ctx.ProtoLibrary.Files()...,
 		),
-		Imports: protoc.FlatMapFiles(
-			grpcImports(),
-			protoc.HasService,
-			ctx.ProtoLibrary.Files()...,
-		),
 	}
 }
 
@@ -52,28 +47,4 @@ func grpcGeneratedFileName(reldir string) func(f *protoc.File) []string {
 		}
 		return []string{name + "_grpc_pb.js"}
 	}
-}
-
-// grpcImports is a utility function that returns a function that
-// computes the name of a predicted imports for a given proto file.
-func grpcImports() func(f *protoc.File) []string {
-	return func(f *protoc.File) []string {
-		imports := make([]string, 0)
-
-		pkg := f.Name + "_grpc_pb"
-		if f.Package().Name != "" {
-			pkg = f.Package().Name + "." + pkg
-		}
-		for _, m := range f.Services() {
-			imports = append(imports, getGrpcNodeImportName(pkg, m.Name))
-		}
-		return imports
-	}
-}
-
-func getGrpcNodeImportName(pkg, name string) string {
-	if pkg == "" {
-		return name
-	}
-	return pkg + "." + name
 }

--- a/pkg/protoc/plugin_configuration.go
+++ b/pkg/protoc/plugin_configuration.go
@@ -24,10 +24,6 @@ type PluginConfiguration struct {
 	Out string
 	// Outputs is the list of output files the plugin generates
 	Outputs []string
-	// Imports is a list of language-specific imports that are provided by the
-	// output files.  This can be used to populate the GazelleImportsKey private
-	// attr for import resolution.
-	Imports []string
 }
 
 // GetPluginLabels returns the list of labels strings for a list of plugins.

--- a/pkg/protoc/protoc_configuration.go
+++ b/pkg/protoc/protoc_configuration.go
@@ -2,7 +2,6 @@ package protoc
 
 import (
 	"path"
-	"sort"
 	"strings"
 )
 
@@ -30,7 +29,6 @@ type ProtocConfiguration struct {
 
 func newProtocConfiguration(lc *LanguageConfig, workDir, rel, prefix string, lib ProtoLibrary, plugins []*PluginConfiguration) *ProtocConfiguration {
 	srcs, mappings := mergeSources(workDir, rel, plugins)
-	imports := mergeImports(plugins)
 
 	return &ProtocConfiguration{
 		LanguageConfig: lc,
@@ -39,7 +37,6 @@ func newProtocConfiguration(lc *LanguageConfig, workDir, rel, prefix string, lib
 		Library:        lib,
 		Plugins:        plugins,
 		Outputs:        srcs,
-		Imports:        imports,
 		Mappings:       mappings,
 	}
 }
@@ -111,17 +108,4 @@ func mergeSources(workDir, rel string, plugins []*PluginConfiguration) ([]string
 	}
 
 	return srcs, mappings
-}
-
-// mergeImports computes the merged list of imports for the list of plugins.
-func mergeImports(plugins []*PluginConfiguration) []string {
-	imports := make([]string, 0)
-
-	for _, plugin := range plugins {
-		imports = append(imports, plugin.Imports...)
-	}
-
-	sort.Strings(imports)
-
-	return imports
 }

--- a/pkg/rule/rules_go/go_library.go
+++ b/pkg/rule/rules_go/go_library.go
@@ -29,26 +29,11 @@ func init() {
 		})
 }
 
-// func hasServicesAndGrpcOption(library protoc.ProtoLibrary, plugin *protoc.PluginConfiguration) bool {
-// 	// if any of the proto_library files have grpc service definitions AND the
-// 	// grpc option is configured, emit a grpc_go_library rule instead.
-// 	if !protoc.HasServices(library.Files()...) {
-// 		return false
-// 	}
-// 	for option, want := range plugin.Config.Options {
-// 		if option == "grpc" && want {
-// 			return true
-// 		}
-// 	}
-// 	return false
-// }
-
 // goLibrary implements LanguageRule for the '{proto|grpc}_go_library' rule from
 // @rules_proto.
 type goLibrary struct {
 	pluginName string
 	kindName   string
-	// shouldProvideRule func(library protoc.ProtoLibrary, plugin *protoc.PluginConfiguration) bool
 }
 
 // Name implements part of the LanguageRule interface.


### PR DESCRIPTION
This was an experiment within python prior to integration with the rules_python gazelle generator and it no longer needed.