### PR TITLE
Enable resolve for proto_py_library deps attr

### DIFF
--- a/pkg/rule/rules_java/proto_java_library.go
+++ b/pkg/rule/rules_java/proto_java_library.go
@@ -29,13 +29,7 @@ func (s *protoJavaLibrary) Name() string {
 
 // KindInfo implements part of the LanguageRule interface.
 func (s *protoJavaLibrary) KindInfo() rule.KindInfo {
-	return rule.KindInfo{
-		MergeableAttrs: map[string]bool{
-			"srcs":    true,
-			"exports": true,
-		},
-		ResolveAttrs: map[string]bool{"deps": true},
-	}
+	return javaLibraryKindInfo
 }
 
 // LoadInfo implements part of the LanguageRule interface.

--- a/pkg/rule/rules_python/py_library.go
+++ b/pkg/rule/rules_python/py_library.go
@@ -18,6 +18,7 @@ var pyLibraryKindInfo = rule.KindInfo{
 		"deps":       true,
 		"visibility": true,
 	},
+	ResolveAttrs: map[string]bool{"deps": true},
 }
 
 // PyLibrary implements RuleProvider for 'py_library'-derived rules.
@@ -89,6 +90,9 @@ func (s *PyLibrary) Rule(otherGen ...*rule.Rule) *rule.Rule {
 
 // Imports implements part of the RuleProvider interface.
 func (s *PyLibrary) Imports(c *config.Config, r *rule.Rule, file *rule.File) []resolve.ImportSpec {
+	if lib, ok := r.PrivateAttr(protoc.ProtoLibraryKey).(protoc.ProtoLibrary); ok {
+		return protoc.ProtoLibraryImportSpecsForKind(r.Kind(), lib)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Not sure if resolving the `deps` attr in the python rules was missed or omitted for some other reason, but without it I was getting targets generated with missing dependencies to other proto targets.

Also deduped the `KindInfo` structure in `proto_java_library`.