### PR TITLE
Respect -proto_repo_name flag for internal resolve labels.

### DIFF
--- a/pkg/language/protobuf/generate.go
+++ b/pkg/language/protobuf/generate.go
@@ -57,7 +57,12 @@ func (pl *protobufLang) GenerateRules(args language.GenerateArgs) language.Gener
 
 	protoLibraries := make([]protoc.ProtoLibrary, 0)
 	for _, r := range args.OtherGen {
-		internalLabel := label.New(args.Config.RepoName, args.Rel, r.Name())
+		// if the repoName has been overridden by a flag (proto_repository rule) use that.
+		repoName := args.Config.RepoName
+		if pl.repoName != "" {
+			repoName = pl.repoName
+		}
+		internalLabel := label.New(repoName, args.Rel, r.Name())
 		protoc.GlobalRuleIndex().Put(internalLabel, r)
 
 		if r.Kind() != "proto_library" {


### PR DESCRIPTION
In https://github.com/stackb/rules_proto/pull/211, internal resolve labels for
the cross-resolver were qualified by the repository name.  The proto_repository
however allows this to be overridden.  This change makes it such that that flag
value is used when defined.