### PR TITLE
Revert label reponame qualification

### DIFF
--- a/pkg/language/protobuf/generate.go
+++ b/pkg/language/protobuf/generate.go
@@ -57,12 +57,7 @@ func (pl *protobufLang) GenerateRules(args language.GenerateArgs) language.Gener
 
 	protoLibraries := make([]protoc.ProtoLibrary, 0)
 	for _, r := range args.OtherGen {
-		// if the repoName has been overridden by a flag (proto_repository rule) use that.
-		repoName := args.Config.RepoName
-		if pl.repoName != "" {
-			repoName = pl.repoName
-		}
-		internalLabel := label.New(repoName, args.Rel, r.Name())
+		internalLabel := label.New("", args.Rel, r.Name())
 		protoc.GlobalRuleIndex().Put(internalLabel, r)
 
 		if r.Kind() != "proto_library" {

--- a/pkg/language/protobuf/generate_test.go
+++ b/pkg/language/protobuf/generate_test.go
@@ -31,7 +31,7 @@ func TestGenerateRules(t *testing.T) {
 				Imports: []interface{}{},
 			},
 		},
-		"registers labels qualified with the config.RepoName": {
+		"does not register labels qualified with the config.RepoName": {
 			files: []testtools.FileSpec{
 				{
 					Path: "foo.proto",
@@ -64,7 +64,7 @@ import "google/protobuf/any.proto";
 						lang:    "proto",
 						impLang: "proto",
 						imp:     "messages.proto",
-						label:   label.New("contoso", "", "foo_library"),
+						label:   label.New("", "", "foo_library"),
 					},
 				}
 				if diff := cmp.Diff(wantProvided, state.resolver.provided, cmp.AllowUnexported(importResolverProvide{})); diff != "" {
@@ -72,7 +72,7 @@ import "google/protobuf/any.proto";
 				}
 			},
 		},
-		"registers labels qualified with the extension.repoName if set": {
+		"does not register labels qualified with the extension.repoName if set": {
 			files: []testtools.FileSpec{
 				{
 					Path: "foo.proto",
@@ -106,7 +106,7 @@ import "google/protobuf/any.proto";
 						lang:    "proto",
 						impLang: "proto",
 						imp:     "messages.proto",
-						label:   label.New("override", "", "foo_library"),
+						label:   label.New("", "", "foo_library"),
 					},
 				}
 				if diff := cmp.Diff(wantProvided, state.resolver.provided, cmp.AllowUnexported(importResolverProvide{})); diff != "" {

--- a/pkg/protoc/package.go
+++ b/pkg/protoc/package.go
@@ -215,7 +215,7 @@ func (s *Package) getProvidedRules(providers []RuleProvider, shouldResolve bool)
 			// the rule ref seems to have changed by that time, the PrivateAttr
 			// is removed.  Maybe this is due to rule merges?  Very difficult to
 			// track down bug that cost me days.
-			from := label.New(s.cfg.config.RepoName, s.rel, r.Name())
+			from := label.New("", s.rel, r.Name())
 			file := rule.EmptyFile("", s.rel)
 			provideResolverImportSpecs(s.cfg.config, p, r, file, from)
 		}


### PR DESCRIPTION
PRs #212, #211 are causing issues with `proto_repository`.  This PR reverts those changes.