### PR TITLE
Fix proto_go_library deps resolution for "merged rules"

### DIFF
--- a/example/golden/testdata/proto_repository/README.md
+++ b/example/golden/testdata/proto_repository/README.md
@@ -5,6 +5,14 @@ A few notes about the test:
 
 - The files are used in both "//example/golden:golden_test" (a golden test) and
   "//example/golden:proto_repository_test" (go_bazel_test).
+- The proto mode is "file", so the proto_library rule for "app.proto" has two
+  dependencies: one for annotations.proto and another for field_behavior.proto.
+  Yet, the proto_go_library has only a single dependency on
+  annotations_go_proto.  This is because go sources that share the same
+  "importpath" must be compiled together under a single go_library rule.
+  Therefore, there is logic that merges proto_go_library rules when they share
+  the same importpath.  The relationship of annotations.proto and
+  field_behavior.proto tests this merge behavior.
 
 ## //example/golden:golden_test (golden test)
 

--- a/example/golden/testdata/proto_repository/imports.csv
+++ b/example/golden/testdata/proto_repository/imports.csv
@@ -1,2 +1,4 @@
 proto,proto,google/api/annotations.proto,@googleapis//google/api:annotations_proto
+proto,proto,google/api/field_behavior.proto,@googleapis//google/api:field_behavior_proto
 protobuf,proto_go_library,google/api/annotations.proto,@googleapis//google/api:annotations_go_proto
+protobuf,proto_go_library,google/api/field_behavior.proto,@googleapis//google/api:annotations_go_proto

--- a/example/golden/testdata/proto_repository/proto/foo/BUILD.out
+++ b/example/golden/testdata/proto_repository/proto/foo/BUILD.out
@@ -6,7 +6,10 @@ proto_library(
     name = "app_proto",
     srcs = ["app.proto"],
     visibility = ["//visibility:public"],
-    deps = ["@googleapis//google/api:annotations_proto"],
+    deps = [
+        "@googleapis//google/api:annotations_proto",
+        "@googleapis//google/api:field_behavior_proto",
+    ],
 )
 
 proto_compile(

--- a/example/golden/testdata/proto_repository/proto/foo/app.proto
+++ b/example/golden/testdata/proto_repository/proto/foo/app.proto
@@ -5,13 +5,14 @@ package proto;
 option go_package = "github.com/example/app";
 
 import "google/api/annotations.proto";
+import "google/api/field_behavior.proto";
 
 message Request {
-    string id = 1;
+    string id = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message Response {
-    string id = 1;
+    string id = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 service Echoer {


### PR DESCRIPTION
If two proto_go_library rules share the same importpath, the srcs and deps
for the two rules are added rather than creating a new rule.  This fixes
a bug whereby the resolver was being populated only for the "merge destination"
rule and not for any "merge source" rules.  google/api/field_behaviour.proto
is an example of a "merge source" type rule, and is added to the proto_repository test.