### PR TITLE
proto_compile.go: implement 'gazelle:proto_rule proto_compile attr verbose true'

### DIFF
--- a/pkg/protoc/language_rule_config.go
+++ b/pkg/protoc/language_rule_config.go
@@ -77,6 +77,16 @@ func (c *LanguageRuleConfig) GetOptions() []string {
 	return opts
 }
 
+// GetAttrNames returns the names of attributes that have configuration.
+func (c *LanguageRuleConfig) GetAttrNames() []string {
+	names := make([]string, 0)
+	for name := range c.Attrs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // GetAttr returns the positive-intent attr values under the given key.
 func (c *LanguageRuleConfig) GetAttr(name string) []string {
 	vals := make([]string, 0)

--- a/pkg/protoc/proto_compile.go
+++ b/pkg/protoc/proto_compile.go
@@ -1,6 +1,7 @@
 package protoc
 
 import (
+	"log"
 	"fmt"
 	"sort"
 
@@ -130,6 +131,26 @@ func (s *protoCompileRule) Rule(otherGen ...*rule.Rule) *rule.Rule {
 	visibility := s.Visibility()
 	if len(visibility) > 0 {
 		newRule.SetAttr("visibility", visibility)
+	}
+
+	for _, name := range s.ruleConfig.GetAttrNames() {
+		vals := s.ruleConfig.GetAttr(name)
+		if len(vals) == 0 {
+			continue
+		}
+		switch name {
+		case "verbose":
+			val := vals[0]
+			if val == "True" || val == "true" {
+				newRule.SetAttr("verbose", true)
+			} else if val == "False" || val == "false" {
+				newRule.SetAttr("verbose", false)
+			} else {
+				log.Printf("bad attr 'verbose' value: %q", val)
+			}
+		default:
+			newRule.SetAttr(name, vals)
+		}
 	}
 
 	return newRule


### PR DESCRIPTION
Allows setting list attributes directly, or the verbose attribute as a bool.