### PR TITLE
{proto, grpc}_scala_library: stop exporting deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BAZEL := bazel
+BAZEL := bzl
 
 .PHONY: tidy
 tidy: deps

--- a/example/golden/testdata/scala/.bazelrc
+++ b/example/golden/testdata/scala/.bazelrc
@@ -1,1 +1,2 @@
 build --proto_compiler=@build_stack_rules_proto//toolchain:protoc.exe
+build --incompatible_java_common_parameters=false

--- a/example/golden/testdata/scala/lib/BUILD.in
+++ b/example/golden/testdata/scala/lib/BUILD.in
@@ -4,5 +4,9 @@ scala_library(
     name = "scala",
     srcs = ["WithSnapshot.scala"],
     visibility = ["//visibility:public"],
-    deps = ["//proto:proto_scala_library"],
+    deps = [,
+        "//proto:proto_scala_library",
+        "@maven_scala//:com_thesamet_scalapb_lenses_2_12",
+        "@maven_scala//:com_thesamet_scalapb_scalapb_runtime_2_12",
+    ],
 )

--- a/example/golden/testdata/scala/lib/BUILD.in
+++ b/example/golden/testdata/scala/lib/BUILD.in
@@ -4,7 +4,7 @@ scala_library(
     name = "scala",
     srcs = ["WithSnapshot.scala"],
     visibility = ["//visibility:public"],
-    deps = [,
+    deps = [
         "//proto:proto_scala_library",
         "@maven_scala//:com_thesamet_scalapb_lenses_2_12",
         "@maven_scala//:com_thesamet_scalapb_scalapb_runtime_2_12",

--- a/example/golden/testdata/scala/lib/BUILD.out
+++ b/example/golden/testdata/scala/lib/BUILD.out
@@ -4,5 +4,9 @@ scala_library(
     name = "scala",
     srcs = ["WithSnapshot.scala"],
     visibility = ["//visibility:public"],
-    deps = ["//proto:proto_scala_library"],
+    deps = [
+        "//proto:proto_scala_library",
+        "@maven_scala//:com_thesamet_scalapb_lenses_2_12",
+        "@maven_scala//:com_thesamet_scalapb_scalapb_runtime_2_12",
+    ],
 )

--- a/rules/private/proto_repository_tools_srcs.bzl
+++ b/rules/private/proto_repository_tools_srcs.bzl
@@ -34,6 +34,7 @@ PROTO_REPOSITORY_TOOLS_SRCS = [
     "@build_stack_rules_proto//pkg/plugin/builtin:js_common_plugin.go",
     "@build_stack_rules_proto//pkg/plugin/builtin:objc_plugin.go",
     "@build_stack_rules_proto//pkg/plugin/builtin:php_plugin.go",
+    "@build_stack_rules_proto//pkg/plugin/builtin:pyi_plugin.go",
     "@build_stack_rules_proto//pkg/plugin/builtin:python_plugin.go",
     "@build_stack_rules_proto//pkg/plugin/builtin:ruby_plugin.go",
     "@build_stack_rules_proto//pkg/plugin/gogo/protobuf:BUILD.bazel",

--- a/rules/scala/grpc_scala_library.bzl
+++ b/rules/scala/grpc_scala_library.bzl
@@ -3,5 +3,4 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 
 def grpc_scala_library(**kwargs):
-    kwargs.setdefault("exports", kwargs.get("deps", []))
     scala_library(**kwargs)

--- a/rules/scala/proto_scala_library.bzl
+++ b/rules/scala/proto_scala_library.bzl
@@ -3,5 +3,4 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 
 def proto_scala_library(**kwargs):
-    kwargs.setdefault("exports", kwargs.get("deps", []))
     scala_library(**kwargs)


### PR DESCRIPTION
This turns out to be more trouble than it's worth by compromising the transparency of direct deps.