### PR TITLE
proto_scala_library: add custom rule options

### DIFF
--- a/go_deps.bzl
+++ b/go_deps.bzl
@@ -32,6 +32,13 @@ def gazelle_protobuf_extension_go_deps():
         sum = "h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=",
         version = "v1.0.0-20180628173108-788fd7840127",
     )
+    go_repository(
+        name = "com_github_bmatcuk_doublestar",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/bmatcuk/doublestar",
+        sum = "h1:oC24CykoSAB8zd7XgruHo33E0cHJf/WhQA/7BeXj+x0=",
+        version = "v1.2.2",
+    )
 
 def go_deps():
     "go_repository rules derived from the go.mod file."
@@ -65,13 +72,6 @@ def go_deps():
         importpath = "github.com/bazelbuild/rules_go",
         sum = "h1:KViqR7qKXwz+LrNdIauCDU21kneCk+4DnYjpvlJwH50=",
         version = "v0.27.0",
-    )
-    go_repository(
-        name = "com_github_bmatcuk_doublestar",
-        build_file_proto_mode = "disable_global",
-        importpath = "github.com/bmatcuk/doublestar",
-        sum = "h1:oC24CykoSAB8zd7XgruHo33E0cHJf/WhQA/7BeXj+x0=",
-        version = "v1.2.2",
     )
     go_repository(
         name = "com_github_burntsushi_toml",

--- a/pkg/protoc/language_rule_config.go
+++ b/pkg/protoc/language_rule_config.go
@@ -64,7 +64,7 @@ func (c *LanguageRuleConfig) GetDeps() []string {
 	return deps
 }
 
-// GetOptions returns the rule options.
+// GetOptions returns the rule options having positive intent.
 func (c *LanguageRuleConfig) GetOptions() []string {
 	opts := make([]string, 0)
 	for opt, want := range c.Options {

--- a/pkg/rule/rules_scala/BUILD.bazel
+++ b/pkg/rule/rules_scala/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "@bazel_gazelle//label:go_default_library",
         "@bazel_gazelle//resolve:go_default_library",
         "@bazel_gazelle//rule:go_default_library",
+        "@com_github_bmatcuk_doublestar//:doublestar",
         "@com_github_emicklei_proto//:proto",
     ],
 )

--- a/pkg/rule/rules_scala/README.md
+++ b/pkg/rule/rules_scala/README.md
@@ -1,0 +1,77 @@
+# scala rules
+
+This package registers two rules:
+
+| Name                  | Implementation                           |
+| --------------------- | ---------------------------------------- |
+| `proto_scala_library` | `stackb:rules_proto:proto_scala_library` |
+| `grpc_scala_library`  | `stackb:rules_proto:grpc_scala_library`  |
+
+These rules have the following characteristics:
+
+- They generate
+  `@build_stack_rules_proto//rules/scala:{proto|grpc}_scala_library`. Both are
+  thin wrappers around `@io_bazel_rules_scala//scala:scala.bzl%scala_library`.
+- The rule suffix is `_scala_library`.
+- `proto_scala_library` is generated if the protos have no services, otherwise
+  `grpc_scala_library` is emitted.
+- They merge on `srcs` and resolve on `deps`.
+- They provide a littany of symbols onto the global resolver, to be
+  theoretically consumed by a separate `scala` gazelle extension (see
+  `provideScalaImports` for details).
+
+Example:
+
+```
+gazelle:proto_rule proto_scala_library implementation stackb:rules_proto:proto_scala_library
+gazelle:proto_rule proto_scala_library deps @maven//:com_google_protobuf_protobuf_java
+gazelle:proto_rule proto_scala_library deps @maven//:com_thesamet_scalapb_lenses_2_12
+gazelle:proto_rule proto_scala_library deps @maven//:com_thesamet_scalapb_scalapb_runtime_2_12
+gazelle:proto_rule proto_scala_library options --noresolve=scalapb/scalapb.proto
+gazelle:proto_rule proto_scala_library options --nooutput=package_scala.srcjar
+gazelle:proto_rule proto_scala_library visibility //visibility:public
+```
+
+The above configuration declares a `proto_scala_library` rule that will
+statically include the thee named deps, and have public visibility.
+
+Consider a proto package that declares "package options" (other proto files in
+this package are ignored for this example):
+
+```proto
+syntax = "proto2";
+
+package example.proto;
+
+import "thirdparty/protobuf/scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+    scope: PACKAGE
+    preserve_unknown_fields: false
+};
+```
+
+In the typical case, the following `proto_library` and `proto_compile` rules
+will be generated:
+
+```
+proto_library(
+    name = "package_proto",
+    srcs = ["package.proto"],
+    deps = ["//thirdparty/protobuf/scalapb:scalapb_proto"],
+)
+
+proto_compile(
+    name = "package_scala_compile",
+    outputs = ["package_scala.srcjar"],
+    plugins = ["@build_stack_rules_proto//rules/scala:protoc-gen-scala"],
+    proto = "package_proto",
+    visibility = ["//visibility:public"],
+)
+```
+
+However, in this case we do not want to emit a `proto_scala_library`. Why?
+Because the `package_scala.srcjar` in this case will be empty, as the scalapbc
+plugin does not emit and corresponding JVM code for this degenerate case.
+
+Therefore, the `--nooutput` means "suppress this output from the output list".

--- a/pkg/rule/rules_scala/scala_library.go
+++ b/pkg/rule/rules_scala/scala_library.go
@@ -75,8 +75,7 @@ func (s *scalaLibrary) Name() string {
 func (s *scalaLibrary) KindInfo() rule.KindInfo {
 	return rule.KindInfo{
 		MergeableAttrs: map[string]bool{
-			"srcs":    true,
-			"exports": true,
+			"srcs": true,
 		},
 		ResolveAttrs: map[string]bool{"deps": true},
 	}
@@ -112,9 +111,6 @@ func (s *scalaLibrary) ProvideRule(cfg *protoc.LanguageRuleConfig, pc *protoc.Pr
 	outputs = options.filterOutputs(outputs)
 	if len(outputs) == 0 {
 		return nil
-	}
-	if len(outputs) == 1 && outputs[0] == "package_scala.srcjar" {
-		log.Fatalf("wtf! %q, got %v", s.kindName, outputs)
 	}
 
 	return &scalaLibraryRule{


### PR DESCRIPTION
This PR adds support for options like `gazelle:proto_rule proto_scala_library option --noresolve=scalapb/scalapb.proto`.
