### PR TITLE
Implement gencopy.package option

### DIFF
--- a/cmd/gencopy/gencopy.go
+++ b/cmd/gencopy/gencopy.go
@@ -185,6 +185,9 @@ func makePkgSrcDstPairs(cfg *Config, pkg *PackageConfig) []*SrcDst {
 }
 
 func makePkgSrcDstPair(cfg *Config, pkg *PackageConfig, src, dst string) *SrcDst {
+	if pkg.TargetPackage != "" {
+		dst = filepath.Join(pkg.TargetPackage, dst)
+	}
 	if pkg.TargetWorkspaceRoot != "" {
 		src = filepath.Join("external", strings.TrimPrefix(src, ".."))
 		dst = filepath.Join(pkg.TargetWorkspaceRoot, dst)

--- a/cmd/gencopy/gencopy_test.go
+++ b/cmd/gencopy/gencopy_test.go
@@ -63,6 +63,13 @@ func TestMakePkgSrcDstPair(t *testing.T) {
 			dst:  "file.txt",
 			want: SrcDst{Src: "external/foo/file.txt", Dst: "/home/external/foo/file.txt"},
 		},
+		"TargetPackage": {
+			cfg:  Config{WorkspaceRootDirectory: "/home"},
+			pkg:  PackageConfig{TargetPackage: "pkg"},
+			src:  "file.txt",
+			dst:  "file.txt",
+			want: SrcDst{Src: "file.txt", Dst: "/home/pkg/file.txt"},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			got := makePkgSrcDstPair(&tc.cfg, &tc.pkg, tc.src, tc.dst)

--- a/rules/golden_filegroup.bzl
+++ b/rules/golden_filegroup.bzl
@@ -53,6 +53,8 @@ def golden_filegroup(
 
     tags = kwargs.pop("tags", [])
     srcs = kwargs.pop("srcs", [])
+    package = kwargs.pop("package", "")
+
     goldens = [src + extension for src in srcs]
     native.filegroup(name = name, srcs = srcs, tags = tags, **kwargs)
 
@@ -60,6 +62,7 @@ def golden_filegroup(
 
     proto_compile_gencopy_test(
         name = name_test,
+        package = package,
         srcs = goldens,
         deps = [name_sources],
         mode = "check",
@@ -70,6 +73,7 @@ def golden_filegroup(
 
     proto_compile_gencopy_run(
         name = name_run,
+        package = package,
         deps = [name_sources],
         mode = "update",
         extension = extension,

--- a/rules/proto_compile_gencopy.bzl
+++ b/rules/proto_compile_gencopy.bzl
@@ -58,10 +58,14 @@ def _proto_compile_gencopy_impl(ctx):
             else:
                 srcs.append(f.short_path)
 
+        package = info.label.package
+        if ctx.attr.package:
+            package = "/".join([ctx.label.package, package])
+
         config.packageConfigs.append(
             struct(
                 targetLabel = str(info.label),
-                targetPackage = info.label.package,
+                targetPackage = package,
                 targetWorkspaceRoot = info.label.workspace_root,
                 generatedFiles = [f.short_path for f in info.outputs],
                 sourceFiles = srcs,
@@ -92,6 +96,9 @@ def _proto_compile_gencopy_rule(is_test):
             extension = attr.string(
                 doc = "optional file extension to add to the copied file",
                 mandatory = False,
+            ),
+            package = attr.string(
+                doc = "The package dir to which the generated files should belong",
             ),
         ),
         executable = True,


### PR DESCRIPTION
New attribute for gencopy that allows the copied files to be rooted at a particular package directory.