### PR TITLE
 Add grpc-web support

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,7 @@ artifact identifiers that follow a GitHub org/repo/plugin_name convention.
 | [grpc:grpc-go:protoc-gen-go-grpc](pkg/plugin/grpc/grpcgo/protoc-gen-go-grpc.go)                                        |
 | [grpc:grpc-java:protoc-gen-grpc-java](pkg/plugin/grpc/grpcjava/protoc-gen-grpc-java.go)                                |
 | [grpc:grpc-node:protoc-gen-grpc-node](pkg/plugin/grpc/grpcnode/protoc-gen-grpc-node.go)                                |
+| [grpc:grpc-web:protoc-gen-grpc-web](pkg/plugin/grpc/grpcweb/protoc-gen-grpc-web.go)                                    |
 | [gogo:protobuf:protoc-gen-combo](pkg/plugin/gogo/protobuf/protoc-gen-gogo.go)                                          |
 | [gogo:protobuf:protoc-gen-gogo](pkg/plugin/gogo/protobuf/protoc-gen-gogo.go)                                           |
 | [gogo:protobuf:protoc-gen-gogofast](pkg/plugin/gogo/protobuf/protoc-gen-gogo.go)                                       |
@@ -803,6 +804,7 @@ artifact identifiers that follow a GitHub org/repo/rule_name convention.
 | [stackb:rules_proto:grpc_closure_js_library](pkg/rule/rules_closure/grpc_closure_js_library.go)   |
 | [stackb:rules_proto:grpc_java_library](pkg/rule/rules_java/grpc_java_library.go)                  |
 | [stackb:rules_proto:grpc_nodejs_library](pkg/rule/rules_nodejs/grpc_nodejs_library.go)            |
+| [stackb:rules_proto:grpc_web_js_library](pkg/rule/rules_nodejs/grpc_web_js_library.go)            |
 | [stackb:rules_proto:grpc_py_library](pkg/rule/rules_python/grpc_py_library.go)                    |
 | [stackb:rules_proto:proto_cc_library](pkg/rule/rules_cc/proto_cc_library.go)                      |
 | [stackb:rules_proto:proto_closure_js_library](pkg/rule/rules_closure/proto_closure_js_library.go) |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,6 +52,10 @@ load("//deps:grpc_node_deps.bzl", "grpc_node_deps")
 
 grpc_node_deps()
 
+load("//deps:grpc_web_deps.bzl", "grpc_web_deps")
+
+grpc_web_deps()
+
 load("//deps:ts_proto_deps.bzl", "ts_proto_deps")
 
 ts_proto_deps()

--- a/cmd/depsgen/config.go
+++ b/cmd/depsgen/config.go
@@ -34,6 +34,7 @@ type ProtoDependencyInfo struct {
 	BuildFileContent   string
 	BuildFileProtoMode string
 	Deps               []*ProtoDependencyInfo
+	Executable         bool
 	Importpath         string
 	Label              string
 	Name               string

--- a/cmd/depsgen/template.go
+++ b/cmd/depsgen/template.go
@@ -29,7 +29,8 @@ def {{ .Dep.Name }}():
         path = "{{ .Dep.Path }}",{{ end }}{{ if .Dep.PackageJson }}
         package_json = "{{ .Dep.PackageJson }}",{{ end }}{{ if .Dep.PackageLockJson }}
         package_lock_json = "{{ .Dep.PackageLockJson }}",{{ end }}{{ if .Dep.YarnLock }}
-        yarn_lock = "{{ .Dep.YarnLock }}",{{ end }}{{ if .Dep.Sha256 }}
+        yarn_lock = "{{ .Dep.YarnLock }}",{{ end }}{{ if .Dep.Executable }}
+        executable = {{ if .Dep.Executable }}True{{ else }}False{{ end }},{{ end }}{{ if .Dep.Sha256 }}
         sha256 = "{{ .Dep.Sha256 }}",{{ end }}{{ if .Dep.StripPrefix }}
         strip_prefix = "{{ .Dep.StripPrefix }}",{{ end }}{{ if .Dep.YarnLock }}
         frozen_lockfile = {{ if .Dep.FrozenLockfile }}True{{ else }}False{{ end }},{{ end }}{{ if .Dep.PackageLockJson }}

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -82,6 +82,15 @@ depsgen(
 )
 
 depsgen(
+    name = "grpc_web",
+    deps = [
+        ":com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_darwin_x86_64",
+        ":com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_linux_x86_64",
+        ":com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_windows_x86_64",
+    ],
+)
+
+depsgen(
     name = "grpc_java",
     deps = ["//deps:io_grpc_grpc_java"],
 )
@@ -502,6 +511,33 @@ proto_dependency(
     repository_rule = "npm_install",
     symlink_node_modules = False,
     deps = ["build_bazel_rules_nodejs"],
+)
+
+# URL: https://github.com/grpc/grpc-web/releases/tag/1.3.1
+proto_dependency(
+    name = "com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_linux_x86_64",
+    executable = True,
+    repository_rule = "http_file",
+    sha256 = "12d3cfefb22e077251e6d1fae2aeaafd7a66518898397c667ba69cdd1260e72a",
+    urls = ["https://github.com/grpc/grpc-web/releases/download/1.3.1/protoc-gen-grpc-web-1.3.1-linux-x86_64"],
+)
+
+# URL: https://github.com/grpc/grpc-web/releases/tag/1.3.1
+proto_dependency(
+    name = "com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_darwin_x86_64",
+    executable = True,
+    repository_rule = "http_file",
+    sha256 = "466ffe6d2096a2e09823ad02170a90a3e9f79d24094ec8ddcaf6c6d4e673aa2c",
+    urls = ["https://github.com/grpc/grpc-web/releases/download/1.3.1/protoc-gen-grpc-web-1.3.1-darwin-x86_64"],
+)
+
+# URL: https://github.com/grpc/grpc-web/releases/tag/1.3.1
+proto_dependency(
+    name = "com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_windows_x86_64",
+    executable = True,
+    repository_rule = "http_file",
+    sha256 = "f7f3d3b8ddcc7f0f8e432e744768682c070491fc1dcacb922343ec8f39c0d115",
+    urls = ["https://github.com/grpc/grpc-web/releases/download/1.3.1/protoc-gen-grpc-web-1.3.1-windows-x86_64.exe"],
 )
 
 filegroup(

--- a/deps/grpc_web_deps.bzl
+++ b/deps/grpc_web_deps.bzl
@@ -1,0 +1,49 @@
+"""
+GENERATED FILE - DO NOT EDIT (created via @build_stack_rules_proto//cmd/depsgen)
+"""
+
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+def _maybe(repo_rule, name, **kwargs):
+    if name not in native.existing_rules():
+        repo_rule(name = name, **kwargs)
+
+def grpc_web_deps():
+    com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_darwin_x86_64()  # via <TOP>
+    com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_linux_x86_64()  # via <TOP>
+    com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_windows_x86_64()  # via <TOP>
+
+
+def com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_darwin_x86_64():
+    _maybe(
+        http_file,
+        name = "com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_darwin_x86_64",
+        executable = True,
+        sha256 = "466ffe6d2096a2e09823ad02170a90a3e9f79d24094ec8ddcaf6c6d4e673aa2c",
+        urls = [
+            "https://github.com/grpc/grpc-web/releases/download/1.3.1/protoc-gen-grpc-web-1.3.1-darwin-x86_64",
+        ],
+    )
+
+def com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_linux_x86_64():
+    _maybe(
+        http_file,
+        name = "com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_linux_x86_64",
+        executable = True,
+        sha256 = "12d3cfefb22e077251e6d1fae2aeaafd7a66518898397c667ba69cdd1260e72a",
+        urls = [
+            "https://github.com/grpc/grpc-web/releases/download/1.3.1/protoc-gen-grpc-web-1.3.1-linux-x86_64",
+        ],
+    )
+
+def com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_windows_x86_64():
+    _maybe(
+        http_file,
+        name = "com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_windows_x86_64",
+        executable = True,
+        sha256 = "f7f3d3b8ddcc7f0f8e432e744768682c070491fc1dcacb922343ec8f39c0d115",
+        urls = [
+            "https://github.com/grpc/grpc-web/releases/download/1.3.1/protoc-gen-grpc-web-1.3.1-windows-x86_64.exe",
+        ],
+    )

--- a/deps/grpc_web_deps.bzl
+++ b/deps/grpc_web_deps.bzl
@@ -2,7 +2,6 @@
 GENERATED FILE - DO NOT EDIT (created via @build_stack_rules_proto//cmd/depsgen)
 """
 
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def _maybe(repo_rule, name, **kwargs):
@@ -13,7 +12,6 @@ def grpc_web_deps():
     com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_darwin_x86_64()  # via <TOP>
     com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_linux_x86_64()  # via <TOP>
     com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_windows_x86_64()  # via <TOP>
-
 
 def com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_darwin_x86_64():
     _maybe(

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -117,16 +117,23 @@
 # gazelle:proto_language closure_js rule proto_closure_js_library
 # gazelle:proto_language closure_js rule grpc_closure_js_library
 
-## node_js ##
+## Javascript ##
 # gazelle:proto_plugin node_js implementation builtin:js:common
 # gazelle:proto_plugin protoc-gen-grpc-node implementation grpc:grpc-node:protoc-gen-grpc-node
 # gazelle:proto_plugin protoc-gen-grpc-node option grpc_js
+# gazelle:proto_plugin protoc-gen-grpc-web implementation grpc:grpc-web:protoc-gen-grpc-web
+# gazelle:proto_plugin protoc-gen-grpc-web option mode=grpcwebtext
+# gazelle:proto_plugin protoc-gen-grpc-web option import_style=commonjs+dts
 # gazelle:proto_rule proto_nodejs_library implementation stackb:rules_proto:proto_nodejs_library
 # gazelle:proto_rule proto_nodejs_library visibility //visibility:public
 # gazelle:proto_rule grpc_nodejs_library implementation stackb:rules_proto:grpc_nodejs_library
 # gazelle:proto_rule grpc_nodejs_library visibility //visibility:public
+# gazelle:proto_rule grpc_web_js_library implementation stackb:rules_proto:grpc_web_js_library
+# gazelle:proto_rule grpc_web_js_library visibility //visibility:public
 # gazelle:proto_language node_js plugin node_js
 # gazelle:proto_language node_js plugin protoc-gen-grpc-node
+# gazelle:proto_language node_js plugin protoc-gen-grpc-web
 # gazelle:proto_language node_js rule proto_compile
 # gazelle:proto_language node_js rule proto_nodejs_library
 # gazelle:proto_language node_js rule grpc_nodejs_library
+# gazelle:proto_language node_js rule grpc_web_js_library

--- a/example/routeguide/BUILD.bazel
+++ b/example/routeguide/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@build_stack_rules_proto//rules/ts:proto_ts_library.bzl", "proto_ts_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@build_stack_rules_proto//rules/cc:grpc_cc_library.bzl", "grpc_cc_library")
 load("@build_stack_rules_proto//rules/cc:proto_cc_library.bzl", "proto_cc_library")
@@ -8,10 +7,12 @@ load("@build_stack_rules_proto//rules/go:proto_go_library.bzl", "proto_go_librar
 load("@build_stack_rules_proto//rules/java:grpc_java_library.bzl", "grpc_java_library")
 load("@build_stack_rules_proto//rules/java:proto_java_library.bzl", "proto_java_library")
 load("@build_stack_rules_proto//rules/nodejs:grpc_nodejs_library.bzl", "grpc_nodejs_library")
+load("@build_stack_rules_proto//rules/nodejs:grpc_web_js_library.bzl", "grpc_web_js_library")
 load("@build_stack_rules_proto//rules/nodejs:proto_nodejs_library.bzl", "proto_nodejs_library")
 load("@build_stack_rules_proto//rules/py:grpc_py_library.bzl", "grpc_py_library")
 load("@build_stack_rules_proto//rules/py:proto_py_library.bzl", "proto_py_library")
 load("@build_stack_rules_proto//rules/scala:grpc_scala_library.bzl", "grpc_scala_library")
+load("@build_stack_rules_proto//rules/ts:proto_ts_library.bzl", "proto_ts_library")
 load("@build_stack_rules_proto//rules:proto_compile.bzl", "proto_compile")
 
 # gazelle:proto_plugin ts_proto option nestJs=true
@@ -192,19 +193,32 @@ grpc_nodejs_library(
     deps = [":routeguide_nodejs_library"],
 )
 
+grpc_web_js_library(
+    name = "routeguide_grpc_web_js_library",
+    srcs = ["routeguide_grpc_web_pb.js"],
+    visibility = ["//visibility:public"],
+    deps = [":routeguide_nodejs_library"],
+)
+
 proto_compile(
     name = "routeguide_node_js_compile",
     options = {
         "@build_stack_rules_proto//plugin/builtin:commonjs": ["import_style=commonjs"],
         "@build_stack_rules_proto//plugin/grpc/grpc-node:protoc-gen-grpc-node": ["grpc_js"],
+        "@build_stack_rules_proto//plugin/grpc/grpc-web:protoc-gen-grpc-web": [
+            "import_style=commonjs+dts",
+            "mode=grpcwebtext",
+        ],
     },
     outputs = [
         "routeguide_grpc_pb.js",
+        "routeguide_grpc_web_pb.js",
         "routeguide_pb.js",
     ],
     plugins = [
         "@build_stack_rules_proto//plugin/builtin:commonjs",
         "@build_stack_rules_proto//plugin/grpc/grpc-node:protoc-gen-grpc-node",
+        "@build_stack_rules_proto//plugin/grpc/grpc-web:protoc-gen-grpc-web",
     ],
     proto = "routeguide_proto",
 )

--- a/language/protobuf/BUILD.bazel
+++ b/language/protobuf/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/plugin/grpc/grpcgo",
         "//pkg/plugin/grpc/grpcjava",
         "//pkg/plugin/grpc/grpcnode",
+        "//pkg/plugin/grpc/grpcweb",
         "//pkg/plugin/grpcecosystem/grpcgateway",
         "//pkg/plugin/scalapb/scalapb",
         "//pkg/plugin/stackb/grpc_js",

--- a/language/protobuf/protobuf.go
+++ b/language/protobuf/protobuf.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/stackb/rules_proto/pkg/plugin/grpc/grpcgo"
 	_ "github.com/stackb/rules_proto/pkg/plugin/grpc/grpcjava"
 	_ "github.com/stackb/rules_proto/pkg/plugin/grpc/grpcnode"
+	_ "github.com/stackb/rules_proto/pkg/plugin/grpc/grpcweb"
 	_ "github.com/stackb/rules_proto/pkg/plugin/grpcecosystem/grpcgateway"
 	_ "github.com/stackb/rules_proto/pkg/plugin/scalapb/scalapb"
 	_ "github.com/stackb/rules_proto/pkg/plugin/stackb/grpc_js"

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -10,6 +10,7 @@ filegroup(
         "//pkg/plugin/grpc/grpcgo:all_files",
         "//pkg/plugin/grpc/grpcjava:all_files",
         "//pkg/plugin/grpc/grpcnode:all_files",
+        "//pkg/plugin/grpc/grpcweb:all_files",
         "//pkg/plugin/grpcecosystem/grpcgateway:all_files",
         "//pkg/plugin/scalapb/scalapb:all_files",
         "//pkg/plugin/stackb/grpc_js:all_files",

--- a/pkg/plugin/grpc/grpcweb/BUILD.bazel
+++ b/pkg/plugin/grpc/grpcweb/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "grpcweb",
+    srcs = ["protoc-gen-grpc-web.go"],
+    importpath = "github.com/stackb/rules_proto/pkg/plugin/grpc/grpcweb",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/protoc",
+        "@bazel_gazelle//label:go_default_library",
+    ],
+)

--- a/pkg/plugin/grpc/grpcweb/BUILD.bazel
+++ b/pkg/plugin/grpc/grpcweb/BUILD.bazel
@@ -10,3 +10,11 @@ go_library(
         "@bazel_gazelle//label:go_default_library",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        "BUILD.bazel",
+    ] + glob(["*.go"]),
+    visibility = ["//pkg:__pkg__"],
+)

--- a/pkg/plugin/grpc/grpcweb/protoc-gen-grpc-web.go
+++ b/pkg/plugin/grpc/grpcweb/protoc-gen-grpc-web.go
@@ -1,0 +1,51 @@
+package grpcnode
+
+import (
+	"path"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/stackb/rules_proto/pkg/protoc"
+)
+
+func init() {
+	protoc.Plugins().MustRegisterPlugin(&ProtocGenGrpcWeb{})
+}
+
+// ProtocGenGrpcWeb implements Plugin for grpc_web_plugin in the
+// grpc/grpc-web repo.
+type ProtocGenGrpcWeb struct{}
+
+// Name implements part of the Plugin interface.
+func (p *ProtocGenGrpcWeb) Name() string {
+	return "grpc:grpc-web:protoc-gen-grpc-web"
+}
+
+// Configure implements part of the Plugin interface.
+func (p *ProtocGenGrpcWeb) Configure(ctx *protoc.PluginContext) *protoc.PluginConfiguration {
+	if !protoc.HasServices(ctx.ProtoLibrary.Files()...) {
+		return nil
+	}
+	return &protoc.PluginConfiguration{
+		Label: label.New("build_stack_rules_proto", "plugin/grpc/grpc-web", "protoc-gen-grpc-web"),
+		Outputs: protoc.FlatMapFiles(
+			grpcGeneratedFileName(ctx.Rel),
+			protoc.HasService,
+			ctx.ProtoLibrary.Files()...,
+		),
+		Options: ctx.PluginConfig.GetOptions(),
+	}
+}
+
+// grpcGeneratedFileName is a utility function that returns a function that
+// computes the name of a predicted generated file having the given extension(s)
+// relative to the given dir.
+func grpcGeneratedFileName(reldir string) func(f *protoc.File) []string {
+	return func(f *protoc.File) []string {
+		name := strings.ReplaceAll(f.Name, "-", "_")
+		if reldir != "" {
+			name = path.Join(reldir, name)
+		}
+		return []string{name + "_grpc_web_pb.js"}
+	}
+}

--- a/pkg/rule/rules_nodejs/BUILD.bazel
+++ b/pkg/rule/rules_nodejs/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "rules_nodejs",
     srcs = [
         "grpc_nodejs_library.go",
+        "grpc_web_js_library.go",
         "js_library.go",
         "proto_nodejs_library.go",
         "proto_ts_library.go",

--- a/pkg/rule/rules_nodejs/grpc_web_js_library.go
+++ b/pkg/rule/rules_nodejs/grpc_web_js_library.go
@@ -1,0 +1,63 @@
+package rules_nodejs
+
+import (
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+
+	"github.com/stackb/rules_proto/pkg/protoc"
+)
+
+const (
+	grpcWebJsLibraryRuleName   = "grpc_web_js_library"
+	grpcWebJsLibraryRuleSuffix = "_grpc_web_js_library"
+)
+
+func init() {
+	protoc.Rules().MustRegisterRule("stackb:rules_proto:grpc_web_js_library", &grpcWebJsLibrary{})
+}
+
+// grpcWebJsLibrary implements LanguageRule for the 'grpc_web_js_library' rule from @rules_proto.
+type grpcWebJsLibrary struct{}
+
+// Name implements part of the LanguageRule interface.
+func (s *grpcWebJsLibrary) Name() string {
+	return grpcWebJsLibraryRuleName
+}
+
+// KindInfo implements part of the LanguageRule interface.
+func (s *grpcWebJsLibrary) KindInfo() rule.KindInfo {
+	return jsLibraryKindInfo
+}
+
+// LoadInfo implements part of the LanguageRule interface.
+func (s *grpcWebJsLibrary) LoadInfo() rule.LoadInfo {
+	return rule.LoadInfo{
+		Name:    "@build_stack_rules_proto//rules/nodejs:grpc_web_js_library.bzl",
+		Symbols: []string{grpcWebJsLibraryRuleName},
+	}
+}
+
+// ProvideRule implements part of the LanguageRule interface.
+func (s *grpcWebJsLibrary) ProvideRule(cfg *protoc.LanguageRuleConfig, pc *protoc.ProtocConfiguration) protoc.RuleProvider {
+	outputs := pc.GetPluginOutputs("grpc:grpc-web:protoc-gen-grpc-web")
+	if len(outputs) == 0 {
+		return nil
+	}
+
+	return &JsLibrary{
+		KindName:       grpcWebJsLibraryRuleName,
+		RuleNameSuffix: grpcWebJsLibraryRuleSuffix,
+		Outputs:        outputs,
+		RuleConfig:     cfg,
+		Config:         pc,
+		Resolver: func(c *config.Config, ix *resolve.RuleIndex, r *rule.Rule, imports []string, from label.Label) {
+			deps := append(r.AttrStrings("deps"), ":"+pc.Library.BaseName()+ProtoNodeJsLibraryRuleSuffix)
+
+			if len(deps) > 0 {
+				r.SetAttr("deps", deps)
+			}
+		},
+	}
+}

--- a/pkg/rule/rules_nodejs/grpc_web_js_library.go
+++ b/pkg/rule/rules_nodejs/grpc_web_js_library.go
@@ -18,7 +18,8 @@ func init() {
 	protoc.Rules().MustRegisterRule("stackb:rules_proto:grpc_web_js_library", &grpcWebJsLibrary{})
 }
 
-// grpcWebJsLibrary implements LanguageRule for the 'grpc_web_js_library' rule from @rules_proto.
+// grpcWebJsLibrary implements LanguageRule for the 'grpc_web_js_library' rule from @build_stack_rules_proto.
+// (which is essentially a wrapper for 'js_library' rule from @build_bazel_rules_nodejs)
 type grpcWebJsLibrary struct{}
 
 // Name implements part of the LanguageRule interface.

--- a/plugin/grpc/grpc-web/BUILD.bazel
+++ b/plugin/grpc/grpc-web/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@build_stack_rules_proto//rules:proto_plugin.bzl", "proto_plugin")
+
+proto_plugin(
+    name = "protoc-gen-grpc-web",
+    tool = select({
+        "@bazel_tools//src/conditions:darwin_x86_64": "@com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_darwin_x86_64//file",
+        "@bazel_tools//src/conditions:linux_x86_64": "@com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_linux_x86_64//file",
+        "@bazel_tools//src/conditions:windows": "@com_github_grpc_grpc_web_releases_download_v1_3_1_protoc_gen_grpc_web_1_3_1_windows_x86_64//file",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = ["BUILD.bazel"],
+    visibility = ["//plugin:__pkg__"],
+)

--- a/rules/nodejs/BUILD.bazel
+++ b/rules/nodejs/BUILD.bazel
@@ -3,6 +3,7 @@ filegroup(
     srcs = [
         "BUILD.bazel",
         "grpc_nodejs_library.bzl",
+        "grpc_web_js_library.bzl",
         "proto_nodejs_library.bzl",
     ],
     visibility = ["//rules:__pkg__"],

--- a/rules/nodejs/grpc_web_js_library.bzl
+++ b/rules/nodejs/grpc_web_js_library.bzl
@@ -1,0 +1,6 @@
+"grpc_web_js_library.bzl provides a js_library for grpc files."
+
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+
+def grpc_web_js_library(**kwargs):
+    js_library(**kwargs)

--- a/rules/private/proto_repository_tools_srcs.bzl
+++ b/rules/private/proto_repository_tools_srcs.bzl
@@ -106,6 +106,7 @@ PROTO_REPOSITORY_TOOLS_SRCS = [
     "@build_stack_rules_proto//pkg/rule/rules_java:proto_java_library.go",
     "@build_stack_rules_proto//pkg/rule/rules_nodejs:BUILD.bazel",
     "@build_stack_rules_proto//pkg/rule/rules_nodejs:grpc_nodejs_library.go",
+    "@build_stack_rules_proto//pkg/rule/rules_nodejs:grpc_web_js_library.go",
     "@build_stack_rules_proto//pkg/rule/rules_nodejs:js_library.go",
     "@build_stack_rules_proto//pkg/rule/rules_nodejs:proto_nodejs_library.go",
     "@build_stack_rules_proto//pkg/rule/rules_nodejs:proto_ts_library.go",

--- a/rules/proto_dependency.bzl
+++ b/rules/proto_dependency.bzl
@@ -1,4 +1,4 @@
-"""proto_dependency.bzl 
+"""proto_dependency.bzl
 """
 
 load("//rules:providers.bzl", "ProtoDependencyInfo")
@@ -10,6 +10,7 @@ def _proto_dependency_impl(ctx):
             buildFileContent = ctx.attr.build_file_content,
             buildFileProtoMode = ctx.attr.build_file_proto_mode,
             deps = [dep[ProtoDependencyInfo] for dep in ctx.attr.deps],
+            executable = ctx.attr.executable if ctx.attr.repository_rule == "http_file" else None,
             importpath = ctx.attr.importpath,
             label = str(ctx.label),
             name = ctx.attr.name,
@@ -44,6 +45,9 @@ proto_dependency = rule(
         "deps": attr.label_list(
             doc = "Additional transitive dependencies",
             providers = [ProtoDependencyInfo],
+        ),
+        "executable": attr.bool(
+            doc = "The executable attribute for http_file",
         ),
         "importpath": attr.string(
             doc = "The importpath attribute for go_repository",

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -35,6 +35,7 @@ ProtoDependencyInfo = provider(
         "buildFileContent": "The build_file_content of this dependency",
         "buildFileProtoMode": "The build_file_proto_mode of this dependency",
         "deps": "The list of deps of this dependency  list<ProtoDependencyInfo>",
+        "executable": "The executable attribute for 'http_file'",
         "importpath": "The proto dependency importpath string",
         "label": "The proto dependency label string",
         "name": "The proto dependency name (should correspond to the workspace name",


### PR DESCRIPTION
Initial grpc-web support with updated examples and readme.
Additionally allows to use executable proto dependencies without wrappers.