### PR TITLE
Enable js_outputs of proto_ts_library

### DIFF
--- a/rules/ts/proto_ts_library.bzl
+++ b/rules/ts/proto_ts_library.bzl
@@ -37,9 +37,9 @@ def _proto_ts_library_impl(ctx):
         dts_outputs.append(
             ctx.actions.declare_file(base + ".d.ts", sibling = f),
         )
-        # js_outputs.append(
-        #     ctx.actions.declare_file(base + ".js", sibling = f),
-        # )
+        js_outputs.append(
+            ctx.actions.declare_file(base + ".js", sibling = f),
+        )
 
     # all outputs (.d.ts + .js)
     outputs = js_outputs + dts_outputs
@@ -98,7 +98,7 @@ proto_ts_library = rule(
         ),
         "tsc": attr.label(
             allow_files = True,
-            cfg = "host",
+            cfg = "exec",
             mandatory = True,
             doc = "typescript compiler executable",
             executable = True,


### PR DESCRIPTION
This was somewhat arbitrarily disabled.  As it turns out, need to
propagate the js files.