### PR TITLE
bugfix: gencopy fails if runfile is a real file

### DIFF
--- a/cmd/gencopy/gencopy.bash.in
+++ b/cmd/gencopy/gencopy.bash.in
@@ -17,8 +17,12 @@ CONFIG_SHORT_PATH=@@CONFIG_SHORT_PATH@@
 # either by reading the symbolic link or reading the runfiles manifest.
 function find_runfile {
   local runfile=$1
-  if [ -f "$runfile" ]; then
+  if [ -L "$runfile" ]; then
     readlink "$runfile"
+    return
+  fi
+  if [ -f "$runfile" ]; then
+    echo "$runfile"
     return
   fi
   runfile=$(echo "$runfile" | sed -e 's!^\(\.\./\|external/\)!!')


### PR DESCRIPTION
readlink returns 1 if the file is not a symlink. Under some conditions, the runfiles may be the real file not a symlink (e.g. RBE, or other sandboxes)