### PR TITLE
Support attr exports with proto_scala_library

### DIFF
--- a/example/golden/testdata/scala/BUILD.in
+++ b/example/golden/testdata/scala/BUILD.in
@@ -1,5 +1,6 @@
 exports_files(["config.yaml"])
 
 # gazelle:proto_language scala enabled true
+# gazelle:proto_rule proto_scala_library attr exports @com_google_protobuf//:protobuf_java
 # gazelle:proto_rule proto_scala_library option --plugins=protoc-gen-scala
 # gazelle:proto_rule grpc_scala_library option --plugins=protoc-gen-akka-grpc

--- a/example/golden/testdata/scala/BUILD.out
+++ b/example/golden/testdata/scala/BUILD.out
@@ -1,5 +1,6 @@
 exports_files(["config.yaml"])
 
 # gazelle:proto_language scala enabled true
+# gazelle:proto_rule proto_scala_library attr exports @com_google_protobuf//:protobuf_java
 # gazelle:proto_rule proto_scala_library option --plugins=protoc-gen-scala
 # gazelle:proto_rule grpc_scala_library option --plugins=protoc-gen-akka-grpc

--- a/example/golden/testdata/scala/proto/BUILD.out
+++ b/example/golden/testdata/scala/proto/BUILD.out
@@ -26,6 +26,7 @@ proto_scala_library(
     name = "proto_proto_scala_library",
     srcs = ["proto_scala.srcjar"],
     visibility = ["//visibility:public"],
+    exports = ["@com_google_protobuf//:protobuf_java"],
     deps = [
         "@com_google_protobuf//:protobuf_java",
         "@maven_scala//:com_thesamet_scalapb_lenses_2_12",

--- a/example/golden/testdata/scala/syntax/BUILD.out
+++ b/example/golden/testdata/scala/syntax/BUILD.out
@@ -60,6 +60,7 @@ proto_scala_library(
     name = "syntax_proto_scala_library",
     srcs = ["syntax_scala.srcjar"],
     visibility = ["//visibility:public"],
+    exports = ["@com_google_protobuf//:protobuf_java"],
     deps = [
         "//lib:scala",
         "//proto:proto_proto_scala_library",

--- a/pkg/rule/rules_scala/scala_library.go
+++ b/pkg/rule/rules_scala/scala_library.go
@@ -61,8 +61,11 @@ func (s *scalaLibrary) Name() string {
 // KindInfo implements part of the LanguageRule interface.
 func (s *scalaLibrary) KindInfo() rule.KindInfo {
 	return rule.KindInfo{
-		MergeableAttrs: map[string]bool{"srcs": true},
-		ResolveAttrs:   map[string]bool{"deps": true},
+		MergeableAttrs: map[string]bool{
+			"srcs":    true,
+			"exports": true,
+		},
+		ResolveAttrs: map[string]bool{"deps": true},
 	}
 }
 
@@ -169,6 +172,11 @@ func (s *scalaLibraryRule) Rule(otherGen ...*rule.Rule) *rule.Rule {
 	deps := s.Deps()
 	if len(deps) > 0 {
 		newRule.SetAttr("deps", deps)
+	}
+
+	exports := s.ruleConfig.GetAttr("exports")
+	if len(exports) > 0 {
+		newRule.SetAttr("exports", exports)
 	}
 
 	visibility := s.Visibility()


### PR DESCRIPTION
This small feature allows one to modify exports attribute of generated _scala_library targets