### PR TITLE
feat: declares bzl_library targets for bzl files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 
@@ -23,6 +24,7 @@ gazelle_binary(
         "@bazel_gazelle//language/go",
         "@bazel_gazelle//language/proto",
         "//language/protobuf",
+        "@bazel_skylib_sources//gazelle/bzl",
     ],
     visibility = ["//visibility:public"],
 )
@@ -63,4 +65,14 @@ filegroup(
         "//toolchain:all_files",
     ] + glob(["vendor/**/*"]),
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "go_deps",
+    srcs = ["go_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rules/private:proto_repository_tools",
+        "@bazel_gazelle//:deps",
+    ],
 )

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_stack_rules_proto//rules:proto_dependency.bzl", "proto_dependency")
 load("@build_stack_rules_proto//rules:depsgen.bzl", "depsgen")
 
@@ -548,4 +549,119 @@ filegroup(
         "BUILD.bazel",
     ] + glob(["*.bzl"]),
     visibility = ["//:__pkg__"],
+)
+
+bzl_library(
+    name = "closure_deps",
+    srcs = ["closure_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "core_deps",
+    srcs = ["core_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "example_routeguide_nodejs_deps",
+    srcs = ["example_routeguide_nodejs_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "@build_bazel_rules_nodejs//:index",
+    ],
+)
+
+bzl_library(
+    name = "go_core_deps",
+    srcs = ["go_core_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_gazelle//:deps"],
+)
+
+bzl_library(
+    name = "grpc_core_deps",
+    srcs = ["grpc_core_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "grpc_deps",
+    srcs = ["grpc_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "grpc_java_deps",
+    srcs = ["grpc_java_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "grpc_js_deps",
+    srcs = ["grpc_js_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "grpc_node_deps",
+    srcs = ["grpc_node_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "grpc_web_deps",
+    srcs = ["grpc_web_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "nodejs_deps",
+    srcs = ["nodejs_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "prebuilt_protoc_deps",
+    srcs = ["prebuilt_protoc_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "protobuf_core_deps",
+    srcs = ["protobuf_core_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "protobuf_deps",
+    srcs = ["protobuf_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "scala_deps",
+    srcs = ["scala_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)
+
+bzl_library(
+    name = "ts_proto_deps",
+    srcs = ["ts_proto_deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@build_bazel_rules_nodejs//:index"],
 )

--- a/deps/core_deps.bzl
+++ b/deps/core_deps.bzl
@@ -14,6 +14,7 @@ def core_deps():
     io_bazel_rules_go()  # via bazel_gazelle
     bazel_gazelle()  # via <TOP>
     rules_proto()  # via <TOP>
+    bazel_skylib_sources()
 
 def io_bazel_rules_go():
     _maybe(
@@ -51,5 +52,19 @@ def rules_proto():
         strip_prefix = "rules_proto-f7a30f6f80006b591fa7c437fe5a951eb10bcbcf",
         urls = [
             "https://github.com/bazelbuild/rules_proto/archive/f7a30f6f80006b591fa7c437fe5a951eb10bcbcf.tar.gz",
+        ],
+    )
+
+def bazel_skylib_sources():
+    # Override bazel_skylib distribution to fetch sources instead
+    # so that the gazelle extension is included
+    # see https://github.com/bazelbuild/bazel-skylib/issues/250
+    http_archive(
+        name = "bazel_skylib_sources",
+        # sha256 = "07b4117379dde7ab382345c3b0f5edfc6b7cff6c93756eac63da121e0bbcc5de",
+        strip_prefix = "bazel-skylib-1.3.0",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/1.3.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.3.0.tar.gz",
         ],
     )

--- a/example/person/BUILD.bazel
+++ b/example/person/BUILD.bazel
@@ -134,7 +134,8 @@ proto_py_library(
 
 proto_compile(
     name = "person_scala_compile",
-    outputs = ["person_scala.srcjar"],
+    options = {"@build_stack_rules_proto//plugin/scalapb/scalapb:protoc-gen-scala": ["grpc"]},
+    outputs = ["person_scala_grpc.srcjar"],
     plugins = ["@build_stack_rules_proto//plugin/scalapb/scalapb:protoc-gen-scala"],
     proto = "person_proto",
 )

--- a/example/place/BUILD.bazel
+++ b/example/place/BUILD.bazel
@@ -133,7 +133,8 @@ proto_py_library(
 
 proto_compile(
     name = "place_scala_compile",
-    outputs = ["place_scala.srcjar"],
+    options = {"@build_stack_rules_proto//plugin/scalapb/scalapb:protoc-gen-scala": ["grpc"]},
+    outputs = ["place_scala_grpc.srcjar"],
     plugins = ["@build_stack_rules_proto//plugin/scalapb/scalapb:protoc-gen-scala"],
     proto = "place_proto",
 )

--- a/example/routeguide/BUILD.bazel
+++ b/example/routeguide/BUILD.bazel
@@ -284,8 +284,8 @@ proto_compile(
     name = "routeguide_scala_compile",
     options = {"@build_stack_rules_proto//plugin/scalapb/scalapb:protoc-gen-scala": ["grpc"]},
     outputs = [
-        "routeguide_scala.srcjar",
         "routeguide_akka_grpc.srcjar",
+        "routeguide_scala_grpc.srcjar",
     ],
     plugins = [
         "@build_stack_rules_proto//plugin/scalapb/scalapb:protoc-gen-scala",

--- a/example/thing/BUILD.bazel
+++ b/example/thing/BUILD.bazel
@@ -119,7 +119,8 @@ proto_py_library(
 
 proto_compile(
     name = "thing_scala_compile",
-    outputs = ["thing_scala.srcjar"],
+    options = {"@build_stack_rules_proto//plugin/scalapb/scalapb:protoc-gen-scala": ["grpc"]},
+    outputs = ["thing_scala_grpc.srcjar"],
     plugins = ["@build_stack_rules_proto//plugin/scalapb/scalapb:protoc-gen-scala"],
     proto = "thing_proto",
 )

--- a/plugin/gogo/protobuf/BUILD.bazel
+++ b/plugin/gogo/protobuf/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_stack_rules_proto//rules:proto_plugin.bzl", "proto_plugin")
 load(
     "@io_bazel_rules_go//proto/wkt:well_known_types.bzl",
@@ -19,4 +20,10 @@ filegroup(
         "variants.bzl",
     ],
     visibility = ["//plugin:__pkg__"],
+)
+
+bzl_library(
+    name = "variants",
+    srcs = ["variants.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     srcs = [
@@ -25,4 +27,116 @@ filegroup(
         "//rules/scala:all_files",
     ],
     visibility = ["//:__pkg__"],
+)
+
+bzl_library(
+    name = "depsgen",
+    srcs = ["depsgen.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@build_stack_rules_proto//rules:providers"],
+)
+
+bzl_library(
+    name = "example",
+    srcs = ["example.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_go//go/tools/bazel_testing:def"],
+)
+
+bzl_library(
+    name = "golden_filegroup",
+    srcs = ["golden_filegroup.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@build_stack_rules_proto//rules:proto_compile_gencopy",
+        "@build_stack_rules_proto//rules:providers",
+    ],
+)
+
+bzl_library(
+    name = "proto_compile",
+    srcs = ["proto_compile.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":providers",
+        "@rules_proto//proto:defs",
+    ],
+)
+
+bzl_library(
+    name = "proto_compile_assets",
+    srcs = ["proto_compile_assets.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [":proto_compile_gencopy"],
+)
+
+bzl_library(
+    name = "proto_compile_gencopy",
+    srcs = ["proto_compile_gencopy.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [":providers"],
+)
+
+bzl_library(
+    name = "proto_compiled_source_update",
+    srcs = ["proto_compiled_source_update.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [":proto_compile_gencopy"],
+)
+
+bzl_library(
+    name = "proto_compiled_sources",
+    srcs = ["proto_compiled_sources.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":proto_compile",
+        ":proto_compile_gencopy",
+    ],
+)
+
+bzl_library(
+    name = "proto_dependency",
+    srcs = ["proto_dependency.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [":providers"],
+)
+
+bzl_library(
+    name = "proto_descriptor_set",
+    srcs = ["proto_descriptor_set.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@rules_proto//proto:defs"],
+)
+
+bzl_library(
+    name = "proto_gazelle",
+    srcs = ["proto_gazelle.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_skylib//lib:shell"],
+)
+
+bzl_library(
+    name = "proto_plugin",
+    srcs = ["proto_plugin.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@build_stack_rules_proto//rules:providers",
+        "@rules_proto//proto:defs",
+    ],
+)
+
+bzl_library(
+    name = "protogenrule",
+    srcs = ["protogenrule.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@build_stack_rules_proto//rules:proto_compile_gencopy",
+        "@build_stack_rules_proto//rules:providers",
+    ],
+)
+
+bzl_library(
+    name = "providers",
+    srcs = ["providers.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/rules/cc/BUILD.bazel
+++ b/rules/cc/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     srcs = [
@@ -6,4 +8,18 @@ filegroup(
         "proto_cc_library.bzl",
     ],
     visibility = ["//rules:__pkg__"],
+)
+
+bzl_library(
+    name = "grpc_cc_library",
+    srcs = ["grpc_cc_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@rules_cc//cc:defs"],
+)
+
+bzl_library(
+    name = "proto_cc_library",
+    srcs = ["proto_cc_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@rules_cc//cc:defs"],
 )

--- a/rules/closure/BUILD.bazel
+++ b/rules/closure/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     srcs = [
@@ -6,4 +8,18 @@ filegroup(
         "proto_closure_js_library.bzl",
     ],
     visibility = ["//rules:__pkg__"],
+)
+
+bzl_library(
+    name = "grpc_closure_js_library",
+    srcs = ["grpc_closure_js_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_closure//closure:defs"],
+)
+
+bzl_library(
+    name = "proto_closure_js_library",
+    srcs = ["proto_closure_js_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_closure//closure:defs"],
 )

--- a/rules/go/BUILD.bazel
+++ b/rules/go/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     srcs = [
@@ -5,4 +7,11 @@ filegroup(
         "proto_go_library.bzl",
     ],
     visibility = ["//rules:__pkg__"],
+)
+
+bzl_library(
+    name = "proto_go_library",
+    srcs = ["proto_go_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_go//go:def"],
 )

--- a/rules/java/BUILD.bazel
+++ b/rules/java/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     srcs = [
@@ -6,4 +8,16 @@ filegroup(
         "proto_java_library.bzl",
     ],
     visibility = ["//rules:__pkg__"],
+)
+
+bzl_library(
+    name = "grpc_java_library",
+    srcs = ["grpc_java_library.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "proto_java_library",
+    srcs = ["proto_java_library.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/rules/nodejs/BUILD.bazel
+++ b/rules/nodejs/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     srcs = [
@@ -7,4 +9,25 @@ filegroup(
         "proto_nodejs_library.bzl",
     ],
     visibility = ["//rules:__pkg__"],
+)
+
+bzl_library(
+    name = "grpc_nodejs_library",
+    srcs = ["grpc_nodejs_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@build_bazel_rules_nodejs//:index"],
+)
+
+bzl_library(
+    name = "grpc_web_js_library",
+    srcs = ["grpc_web_js_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@build_bazel_rules_nodejs//:index"],
+)
+
+bzl_library(
+    name = "proto_nodejs_library",
+    srcs = ["proto_nodejs_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@build_bazel_rules_nodejs//:index"],
 )

--- a/rules/private/BUILD.bazel
+++ b/rules/private/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 exports_files(
     ["list_repository_tools_srcs.go"],
     visibility = ["//visibility:public"],
@@ -13,4 +15,27 @@ filegroup(
         "proto_repository_tools_srcs.bzl",
     ],
     visibility = ["//rules:__pkg__"],
+)
+
+bzl_library(
+    name = "execution",
+    srcs = ["execution.bzl"],
+    visibility = ["//rules:__subpackages__"],
+)
+
+bzl_library(
+    name = "proto_repository_tools",
+    srcs = ["proto_repository_tools.bzl"],
+    visibility = ["//rules:__subpackages__"],
+    deps = [
+        ":execution",
+        "@bazel_gazelle//internal:go_repository_cache",
+        "@build_stack_rules_proto//rules/private:proto_repository_tools_srcs",
+    ],
+)
+
+bzl_library(
+    name = "proto_repository_tools_srcs",
+    srcs = ["proto_repository_tools_srcs.bzl"],
+    visibility = ["//rules:__subpackages__"],
 )

--- a/rules/proto/BUILD.bazel
+++ b/rules/proto/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     srcs = [
@@ -5,4 +7,15 @@ filegroup(
         "proto_repository.bzl",
     ],
     visibility = ["//rules:__pkg__"],
+)
+
+bzl_library(
+    name = "proto_repository",
+    srcs = ["proto_repository.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rules/private:execution",
+        "@bazel_gazelle//internal:go_repository_cache",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
+    ],
 )

--- a/rules/py/BUILD.bazel
+++ b/rules/py/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     srcs = [
@@ -6,4 +8,18 @@ filegroup(
         "proto_py_library.bzl",
     ],
     visibility = ["//rules:__pkg__"],
+)
+
+bzl_library(
+    name = "grpc_py_library",
+    srcs = ["grpc_py_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@rules_python//python:defs"],
+)
+
+bzl_library(
+    name = "proto_py_library",
+    srcs = ["proto_py_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@rules_python//python:defs"],
 )

--- a/rules/scala/BUILD.bazel
+++ b/rules/scala/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "all_files",
     srcs = [
@@ -7,4 +9,25 @@ filegroup(
         "scala_proto_library.bzl",
     ],
     visibility = ["//rules:__pkg__"],
+)
+
+bzl_library(
+    name = "grpc_scala_library",
+    srcs = ["grpc_scala_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_scala//scala"],
+)
+
+bzl_library(
+    name = "proto_scala_library",
+    srcs = ["proto_scala_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_scala//scala"],
+)
+
+bzl_library(
+    name = "scala_proto_library",
+    srcs = ["scala_proto_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_scala//scala_proto"],
 )

--- a/rules/ts/BUILD.bazel
+++ b/rules/ts/BUILD.bazel
@@ -1,6 +1,15 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 # gazelle:exclude node_modules
 
 exports_files([
     "package.json",
     "yarn.lock",
 ])
+
+bzl_library(
+    name = "proto_ts_library",
+    srcs = ["proto_ts_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@build_bazel_rules_nodejs//:providers"],
+)

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//toolchain:toolchain.bzl", "protoc")
 
 toolchain_type(
@@ -63,4 +64,10 @@ filegroup(
         "toolchain.bzl",
     ],
     visibility = ["//:__pkg__"],
+)
+
+bzl_library(
+    name = "toolchain",
+    srcs = ["toolchain.bzl"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Hi 👋🏼 unsolicited contribution with no expectations to be accepted. We use this repo for some of our stuff and it gets hard to use stardoc without bzl_library targets. This PR adds them.

Uses bazel-skylib's gazelle plugin to generate bzl_library targets. This is useful for dependents of these rules so they can use tools like stardoc to generate documentation.

Note: it looks like there are other changes, but all I did was run `bazel run //:gazelle`.