### PR TITLE
scala library: warn about absent --plugins configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BAZEL := bzl
+BAZEL := bazel
 
 .PHONY: tidy
 tidy: deps

--- a/example/golden/testdata/scala/BUILD.in
+++ b/example/golden/testdata/scala/BUILD.in
@@ -2,5 +2,3 @@ exports_files(["config.yaml"])
 
 # gazelle:proto_language scala enabled true
 # gazelle:proto_rule proto_scala_library attr exports @com_google_protobuf//:protobuf_java
-# gazelle:proto_rule proto_scala_library option --plugins=protoc-gen-scala
-# gazelle:proto_rule grpc_scala_library option --plugins=protoc-gen-akka-grpc

--- a/example/golden/testdata/scala/BUILD.out
+++ b/example/golden/testdata/scala/BUILD.out
@@ -2,5 +2,3 @@ exports_files(["config.yaml"])
 
 # gazelle:proto_language scala enabled true
 # gazelle:proto_rule proto_scala_library attr exports @com_google_protobuf//:protobuf_java
-# gazelle:proto_rule proto_scala_library option --plugins=protoc-gen-scala
-# gazelle:proto_rule grpc_scala_library option --plugins=protoc-gen-akka-grpc

--- a/example/golden/testdata/scala/config.yaml
+++ b/example/golden/testdata/scala/config.yaml
@@ -13,16 +13,16 @@ rules:
     implementation: stackb:rules_proto:proto_compile
   - name: proto_scala_library
     implementation: stackb:rules_proto:proto_scala_library
-    visibility:
-      - //visibility:public
     deps:
       - "@com_google_protobuf//:protobuf_java"
       - "@maven_scala//:com_thesamet_scalapb_lenses_2_12"
       - "@maven_scala//:com_thesamet_scalapb_scalapb_runtime_2_12"
-  - name: grpc_scala_library
-    implementation: stackb:rules_proto:grpc_scala_library
+    options:
+      - "--plugins=protoc-gen-scala"
     visibility:
       - //visibility:public
+  - name: grpc_scala_library
+    implementation: stackb:rules_proto:grpc_scala_library
     deps:
       - "@com_google_protobuf//:protobuf_java"
       - "@maven_akka//:com_lightbend_akka_grpc_akka_grpc_runtime_2_12"
@@ -35,6 +35,10 @@ rules:
       - "@maven_scala//:io_grpc_grpc_api"
       - "@maven_scala//:io_grpc_grpc_protobuf"
       - "@maven_scala//:io_grpc_grpc_stub"
+    options:
+      - "--plugins=protoc-gen-akka-grpc"
+    visibility:
+      - //visibility:public
 languages:
   - name: scala
     plugins:

--- a/example/golden/testdata/scala/syntax/BUILD.out
+++ b/example/golden/testdata/scala/syntax/BUILD.out
@@ -24,6 +24,7 @@ grpc_scala_library(
     visibility = ["//visibility:public"],
     deps = [
         ":syntax_proto_scala_library",
+        "//lib:scala",
         "//proto:proto_proto_scala_library",
         "@com_google_protobuf//:protobuf_java",
         "@maven_akka//:com_lightbend_akka_grpc_akka_grpc_runtime_2_12",

--- a/pkg/rule/rules_scala/scala_library.go
+++ b/pkg/rule/rules_scala/scala_library.go
@@ -89,6 +89,10 @@ func (s *scalaLibrary) ProvideRule(cfg *protoc.LanguageRuleConfig, pc *protoc.Pr
 	// the list of output files
 	outputs := make([]string, 0)
 
+	if len(options.plugins) == 0 {
+		log.Printf("warning: the rule %s should have at least one plugin name for the --plugins option.  This informs the rule which plugin(s) outputs correspond to this library rule", s.Name())
+	}
+
 	for _, name := range options.plugins {
 		plugin := getPluginConfiguration(pc.Plugins, name)
 		if plugin == nil {


### PR DESCRIPTION
The `--plugins` option was added previously to be able to make the plugin/rule relationship configurable.  When that configuration is missing, it can be quite confusing why `proto_scala_library` is not being generated.