### PR TITLE
Incremental update bazel-gazelle

### DIFF
--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -109,14 +109,18 @@ proto_dependency(
     visibility = ["//visibility:public"],
 )
 
-# Commit: 6ce3318b09d545b0f4fb689e715a5fdb237abf26
-# Date: 2021-12-01 19:18:30 +0000 UTC
-# URL: https://github.com/bazelbuild/bazel-gazelle/commit/6ce3318b09d545b0f4fb689e715a5fdb237abf26
+# Commit: ba090ac841ca2a1211a21ce3dee38ea597b00099
+# Date: 2022-01-19 22:51:32 +0000 UTC
+# URL: https://github.com/bazelbuild/bazel-gazelle/commit/ba090ac841ca2a1211a21ce3dee38ea597b00099
 #
-# README: recommend putting dependencies prior to rules_go/gazelle deps (#1142)
+# language/proto: don't skip same-package imports in per-file mode (#1158)
 #
-# Updates #1115
-# Size: 1419181 (1.4 MB)
+# * Don't skip same-package imports in per-file mode
+#
+# * Adds test to ensure that same-package imports are retained in file mode
+#
+# * Add comment to file mode test.
+# Size: 1420584 (1.4 MB)
 proto_dependency(
     name = "bazel_gazelle",
     patch_args = ["-p1"],

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -120,11 +120,14 @@ proto_dependency(
 proto_dependency(
     name = "bazel_gazelle",
     patch_args = ["-p1"],
-    patches = ["@build_stack_rules_proto//third_party:bazel-gazelle-PR1274.patch"],
+    patches = [
+        "@build_stack_rules_proto//third_party:bazel-gazelle-PR1274.patch",
+        "@build_stack_rules_proto//third_party:bazel-gazelle-revert-1152.patch",
+    ],
     repository_rule = "http_archive",
-    sha256 = "485d71985fd779fe033d14fc1327506fbd30d8d28742c41409e4b90f0756b503",
-    strip_prefix = "bazel-gazelle-6ce3318b09d545b0f4fb689e715a5fdb237abf26",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/6ce3318b09d545b0f4fb689e715a5fdb237abf26.tar.gz"],
+    sha256 = "fd86cd74ceaa68f0a6998c255d5f570a6cc20c345652da9d757352ac9e8c6cc9",
+    strip_prefix = "bazel-gazelle-ba090ac841ca2a1211a21ce3dee38ea597b00099",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/ba090ac841ca2a1211a21ce3dee38ea597b00099.tar.gz"],
     deps = [":io_bazel_rules_go"],
 )
 

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -109,18 +109,12 @@ proto_dependency(
     visibility = ["//visibility:public"],
 )
 
-# Commit: ba090ac841ca2a1211a21ce3dee38ea597b00099
-# Date: 2022-01-19 22:51:32 +0000 UTC
-# URL: https://github.com/bazelbuild/bazel-gazelle/commit/ba090ac841ca2a1211a21ce3dee38ea597b00099
+# Commit: 6adf61901eee7e6de7d8ab3af0fc15d06982ad34
+# Date: 2022-03-16 21:48:10 +0000 UTC
+# URL: https://github.com/bazelbuild/bazel-gazelle/commit/6adf61901eee7e6de7d8ab3af0fc15d06982ad34
 #
-# language/proto: don't skip same-package imports in per-file mode (#1158)
-#
-# * Don't skip same-package imports in per-file mode
-#
-# * Adds test to ensure that same-package imports are retained in file mode
-#
-# * Add comment to file mode test.
-# Size: 1420584 (1.4 MB)
+# ci: Add gazelle check (#1203)
+# Size: 1432187 (1.4 MB)
 proto_dependency(
     name = "bazel_gazelle",
     patch_args = ["-p1"],
@@ -129,9 +123,9 @@ proto_dependency(
         "@build_stack_rules_proto//third_party:bazel-gazelle-revert-1152.patch",
     ],
     repository_rule = "http_archive",
-    sha256 = "fd86cd74ceaa68f0a6998c255d5f570a6cc20c345652da9d757352ac9e8c6cc9",
-    strip_prefix = "bazel-gazelle-ba090ac841ca2a1211a21ce3dee38ea597b00099",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/ba090ac841ca2a1211a21ce3dee38ea597b00099.tar.gz"],
+    sha256 = "9a67de0258804915cda489cf0925d9b5894ee77c021a83cee9a2f405b2a95048",
+    strip_prefix = "bazel-gazelle-6adf61901eee7e6de7d8ab3af0fc15d06982ad34",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/6adf61901eee7e6de7d8ab3af0fc15d06982ad34.tar.gz"],
     deps = [":io_bazel_rules_go"],
 )
 

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -109,30 +109,22 @@ proto_dependency(
     visibility = ["//visibility:public"],
 )
 
-# Branch: master
-# Commit: 425d85daecb9aeffa1ae24b83df7b97b534dcf05
-# Date: 2021-10-29 00:25:25 +0000 UTC
-# URL: https://github.com/bazelbuild/bazel-gazelle/commit/425d85daecb9aeffa1ae24b83df7b97b534dcf05
+# Commit: 6ce3318b09d545b0f4fb689e715a5fdb237abf26
+# Date: 2021-12-01 19:18:30 +0000 UTC
+# URL: https://github.com/bazelbuild/bazel-gazelle/commit/6ce3318b09d545b0f4fb689e715a5fdb237abf26
 #
-# Stardoc generates repository.md (#1123)
+# README: recommend putting dependencies prior to rules_go/gazelle deps (#1142)
 #
-# * Stardoc generates repository.md
-#
-# This is a mirror of the content in repository.rst, allowing us to manually inspect the delta between them.
-# As soon as we are satisfied that the generated content is correct, we'll delete repository.rst and update any links to it.
-#
-# Technique: copied doc strings out of existing rst file into the starlark files. Transcribed rst syntax to markdown.
-#
-# * Replace repository.rst content with link to markdown version
-# Size: 1416940 (1.4 MB)
+# Updates #1115
+# Size: 1419181 (1.4 MB)
 proto_dependency(
     name = "bazel_gazelle",
     patch_args = ["-p1"],
     patches = ["@build_stack_rules_proto//third_party:bazel-gazelle-PR1274.patch"],
     repository_rule = "http_archive",
-    sha256 = "cb05501bd37e2cbfdea8e23b28e5a7fe4ff4f12cef30eeb1924a0b8c3c0cea61",
-    strip_prefix = "bazel-gazelle-425d85daecb9aeffa1ae24b83df7b97b534dcf05",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/425d85daecb9aeffa1ae24b83df7b97b534dcf05.tar.gz"],
+    sha256 = "485d71985fd779fe033d14fc1327506fbd30d8d28742c41409e4b90f0756b503",
+    strip_prefix = "bazel-gazelle-6ce3318b09d545b0f4fb689e715a5fdb237abf26",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/6ce3318b09d545b0f4fb689e715a5fdb237abf26.tar.gz"],
     deps = [":io_bazel_rules_go"],
 )
 

--- a/deps/core_deps.bzl
+++ b/deps/core_deps.bzl
@@ -30,13 +30,14 @@ def bazel_gazelle():
     _maybe(
         http_archive,
         name = "bazel_gazelle",
-        sha256 = "485d71985fd779fe033d14fc1327506fbd30d8d28742c41409e4b90f0756b503",
-        strip_prefix = "bazel-gazelle-6ce3318b09d545b0f4fb689e715a5fdb237abf26",
+        sha256 = "fd86cd74ceaa68f0a6998c255d5f570a6cc20c345652da9d757352ac9e8c6cc9",
+        strip_prefix = "bazel-gazelle-ba090ac841ca2a1211a21ce3dee38ea597b00099",
         urls = [
-            "https://github.com/bazelbuild/bazel-gazelle/archive/6ce3318b09d545b0f4fb689e715a5fdb237abf26.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/archive/ba090ac841ca2a1211a21ce3dee38ea597b00099.tar.gz",
         ],
         patches = [
             "@build_stack_rules_proto//third_party:bazel-gazelle-PR1274.patch",
+            "@build_stack_rules_proto//third_party:bazel-gazelle-revert-1152.patch",
         ],
         patch_args = [
             "-p1",

--- a/deps/core_deps.bzl
+++ b/deps/core_deps.bzl
@@ -30,10 +30,10 @@ def bazel_gazelle():
     _maybe(
         http_archive,
         name = "bazel_gazelle",
-        sha256 = "cb05501bd37e2cbfdea8e23b28e5a7fe4ff4f12cef30eeb1924a0b8c3c0cea61",
-        strip_prefix = "bazel-gazelle-425d85daecb9aeffa1ae24b83df7b97b534dcf05",
+        sha256 = "485d71985fd779fe033d14fc1327506fbd30d8d28742c41409e4b90f0756b503",
+        strip_prefix = "bazel-gazelle-6ce3318b09d545b0f4fb689e715a5fdb237abf26",
         urls = [
-            "https://github.com/bazelbuild/bazel-gazelle/archive/425d85daecb9aeffa1ae24b83df7b97b534dcf05.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/archive/6ce3318b09d545b0f4fb689e715a5fdb237abf26.tar.gz",
         ],
         patches = [
             "@build_stack_rules_proto//third_party:bazel-gazelle-PR1274.patch",

--- a/deps/core_deps.bzl
+++ b/deps/core_deps.bzl
@@ -30,10 +30,10 @@ def bazel_gazelle():
     _maybe(
         http_archive,
         name = "bazel_gazelle",
-        sha256 = "fd86cd74ceaa68f0a6998c255d5f570a6cc20c345652da9d757352ac9e8c6cc9",
-        strip_prefix = "bazel-gazelle-ba090ac841ca2a1211a21ce3dee38ea597b00099",
+        sha256 = "9a67de0258804915cda489cf0925d9b5894ee77c021a83cee9a2f405b2a95048",
+        strip_prefix = "bazel-gazelle-6adf61901eee7e6de7d8ab3af0fc15d06982ad34",
         urls = [
-            "https://github.com/bazelbuild/bazel-gazelle/archive/ba090ac841ca2a1211a21ce3dee38ea597b00099.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/archive/6adf61901eee7e6de7d8ab3af0fc15d06982ad34.tar.gz",
         ],
         patches = [
             "@build_stack_rules_proto//third_party:bazel-gazelle-PR1274.patch",

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -3,9 +3,13 @@ filegroup(
     srcs = [
         "BUILD.bazel",
         "bazel-gazelle-PR1274.patch",
+        "bazel-gazelle-revert-1152.patch",
         "zlib.BUILD",
     ],
     visibility = ["//:__pkg__"],
 )
 
-exports_files(["bazel-gazelle-PR1274.patch"])
+exports_files([
+    "bazel-gazelle-PR1274.patch",
+    "bazel-gazelle-revert-1152.patch",
+])

--- a/third_party/bazel-gazelle-revert-1152.patch
+++ b/third_party/bazel-gazelle-revert-1152.patch
@@ -1,0 +1,17 @@
+diff --git a/language/proto/generate.go b/language/proto/generate.go
+index afa0cbe..48bddc9 100644
+--- a/language/proto/generate.go
++++ b/language/proto/generate.go
+@@ -235,12 +235,6 @@ func generateProto(pc *ProtoConfig, rel string, pkg *Package, shouldSetVisibilit
+ 	r.SetPrivateAttr(PackageKey, *pkg)
+ 	imports := make([]string, 0, len(pkg.Imports))
+ 	for i := range pkg.Imports {
+-		// If FileMode isn't enabled and the proto import is a self import
+-		// (an import between the same package), skip it
+-		if pc.Mode != FileMode && getPrefix(pc, path.Dir(i)) == getPrefix(pc, rel) {
+-			delete(pkg.Imports, i)
+-			continue
+-		}
+ 		imports = append(imports, i)
+ 	}
+ 	sort.Strings(imports)


### PR DESCRIPTION
Finding several issues uograding bazel-gazelle to v0.25.0.  This PR attempts to take it up to just before the failing commit.