### PR TITLE
Upgrade gazelle past "static resolution mode"

### DIFF
--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -109,12 +109,12 @@ proto_dependency(
     visibility = ["//visibility:public"],
 )
 
-# Commit: 6adf61901eee7e6de7d8ab3af0fc15d06982ad34
-# Date: 2022-03-16 21:48:10 +0000 UTC
-# URL: https://github.com/bazelbuild/bazel-gazelle/commit/6adf61901eee7e6de7d8ab3af0fc15d06982ad34
+# Commit: 9c475138e6c118b55309a55dbf28de77bcf77621
+# Date: 2022-03-17 20:17:55 +0000 UTC
+# URL: https://github.com/bazelbuild/bazel-gazelle/commit/9c475138e6c118b55309a55dbf28de77bcf77621
 #
-# ci: Add gazelle check (#1203)
-# Size: 1432187 (1.4 MB)
+# language/go: introduce static dependency resolution mode (#1201)
+# Size: 1432641 (1.4 MB)
 proto_dependency(
     name = "bazel_gazelle",
     patch_args = ["-p1"],
@@ -123,9 +123,9 @@ proto_dependency(
         "@build_stack_rules_proto//third_party:bazel-gazelle-revert-1152.patch",
     ],
     repository_rule = "http_archive",
-    sha256 = "9a67de0258804915cda489cf0925d9b5894ee77c021a83cee9a2f405b2a95048",
-    strip_prefix = "bazel-gazelle-6adf61901eee7e6de7d8ab3af0fc15d06982ad34",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/6adf61901eee7e6de7d8ab3af0fc15d06982ad34.tar.gz"],
+    sha256 = "8d52c5444ac9efd8f9e5d449540c5ced2fdf05a29aed821e372d6e7f8ebca259",
+    strip_prefix = "bazel-gazelle-9c475138e6c118b55309a55dbf28de77bcf77621",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/9c475138e6c118b55309a55dbf28de77bcf77621.tar.gz"],
     deps = [":io_bazel_rules_go"],
 )
 

--- a/deps/core_deps.bzl
+++ b/deps/core_deps.bzl
@@ -30,10 +30,10 @@ def bazel_gazelle():
     _maybe(
         http_archive,
         name = "bazel_gazelle",
-        sha256 = "9a67de0258804915cda489cf0925d9b5894ee77c021a83cee9a2f405b2a95048",
-        strip_prefix = "bazel-gazelle-6adf61901eee7e6de7d8ab3af0fc15d06982ad34",
+        sha256 = "8d52c5444ac9efd8f9e5d449540c5ced2fdf05a29aed821e372d6e7f8ebca259",
+        strip_prefix = "bazel-gazelle-9c475138e6c118b55309a55dbf28de77bcf77621",
         urls = [
-            "https://github.com/bazelbuild/bazel-gazelle/archive/6adf61901eee7e6de7d8ab3af0fc15d06982ad34.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/archive/9c475138e6c118b55309a55dbf28de77bcf77621.tar.gz",
         ],
         patches = [
             "@build_stack_rules_proto//third_party:bazel-gazelle-PR1274.patch",

--- a/example/golden/testdata/proto_repository/WORKSPACE
+++ b/example/golden/testdata/proto_repository/WORKSPACE
@@ -2,6 +2,12 @@
 # proto_repository
 # ----------------------------------------------------
 
+# gazelle:repository go_repository name=org_golang_google_protobuf importpath=google.golang.org/protobuf
+# gazelle:repository go_repository name=org_golang_x_net importpath=golang.org/x/net
+# gazelle:repository go_repository name=org_golang_x_sys importpath=golang.org/x/sys
+# gazelle:repository go_repository name=org_golang_x_text importpath=golang.org/x/text
+# gazelle:repository go_repository name=org_golang_x_xerrors importpath=golang.org/x/xerrors
+
 load("@build_stack_rules_proto//rules/proto:proto_repository.bzl", "proto_repository")
 
 proto_repository(


### PR DESCRIPTION
Previously, gazelle used `go list` to assist with resolving various importpaths to their corresponding go_repository name (TODO: which ones exactly?).  With https://github.com/bazelbuild/bazel-gazelle/pull/1201, this behavior was suddenly changed from "external" to "static" mode. 

In this mode, gazelle's internal "RemoteCache" only consults statically known import root mappings.  Those mappings are populated by:
- the `-known_import` gazelle flag
- `go_repository` rules listed in the `WORKSPACE` ^1
- `gazelle:repository` directives (e.g. `# gazelle:repository go_repository name=org_golang_x_text importpath=golang.org/x/text`).

> ^1: What's notably missing here is that the cache is NOT populated by macro files.  So if you use a pattern like the following, none of those go_deps will influence the cache mappings:

```bazel
load("//:go_deps.bzl", "go_deps")

# gazelle:repository_macro go_deps.bzl%go_deps
go_deps()
```

Frustratingly, the new behavior silently ignores cache misses which lead to missing `deps` in the generated `go_library` rules:

```diff
// RootStatic checks the cache to see if the provided importpath matches any known roots.
// If no matches are found, rather than going out to the network to determine the root,
// nothing is returned.
func (r *RemoteCache) RootStatic(importPath string) (root, name string, err error) {
	for prefix := importPath; prefix != "." && prefix != "/"; prefix = path.Dir(prefix){
		v, ok, err := r.root.get(prefix)
		if ok {
			if err != nil {
				return "", "", err
			}
			value := v.(rootValue)
			return value.root, value.name, nil
		}
	}
+      # this would have saved a lot of time!
+      log.Printf("repository cache: failed to resolve known root for %q", importPath)	
	return "", "", nil
}
```

These errors manifest like:

```
        ERROR: /private/var/tmp/_bazel_i868039/19e7e34f72df60c063703407d799c126/external/net_starlark_go/starlark/BUILD.bazel:3:11: GoCompilePkg external/net_starlark_go/starlark/starlark.a failed: (Exit 1): builder failed: error executing command bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix darwin_amd64 -src external/net_starlark_go/starlark/debug.go -src ... (remaining 49 arguments skipped)

        Use --sandbox_debug to see verbose messages from the sandbox
        compilepkg: missing strict dependencies:
        	/private/var/tmp/_bazel_i868039/19e7e34f72df60c063703407d799c126/sandbox/darwin-sandbox/678/execroot/__main__/external/net_starlark_go/starlark/int_posix64.go: import of "golang.org/x/sys/unix"
        No dependencies were provided.
        Check that imports in Go sources match importpath attributes in deps.
```

This PR advances the bazel-gazelle commit past static resolution mode and adds in `gazelle:repository` directives to explicitly populate the needed mappings for the `proto_repository_test` go_bazel_test.