### PR TITLE
scala example: no longer specify 'grpc' option statically

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,3 @@
 build:bazelci --deleted_packages=docs
+# workaround for scala
+build --incompatible_java_common_parameters=false

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -45,7 +45,6 @@
 
 ## Scala ##
 # gazelle:proto_plugin scala implementation scalapb:scalapb:protoc-gen-scala
-# gazelle:proto_plugin scala option grpc
 # gazelle:proto_plugin scala deps @com_google_protobuf//:protobuf_java
 # gazelle:proto_plugin scala deps @maven_scala//:com_thesamet_scalapb_lenses_2_12
 # gazelle:proto_plugin scala deps @maven_scala//:com_thesamet_scalapb_scalapb_runtime_2_12

--- a/example/routeguide/BUILD.bazel
+++ b/example/routeguide/BUILD.bazel
@@ -282,7 +282,6 @@ grpc_scala_library(
 
 proto_compile(
     name = "routeguide_scala_compile",
-    options = {"@build_stack_rules_proto//plugin/scalapb/scalapb:protoc-gen-scala": ["grpc"]},
     outputs = [
         "routeguide_scala.srcjar",
         "routeguide_akka_grpc.srcjar",


### PR DESCRIPTION
The plugin for scala adds "grpc" into the options based on if there are services present, and no longer needs to be specified in the config like this.  This change fixes 'bazel run //:gazelle` for the examples.