### PR TITLE
scala resolve: suppress self-referential imports 

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -13,31 +13,31 @@ plugins:
   - name: protoc-gen-go-grpc
     implementation: grpc:grpc-go:protoc-gen-go-grpc
     deps:
-      - "@org_golang_google_grpc//:go_default_library",
-      - "@org_golang_google_grpc//codes",
-      - "@org_golang_google_grpc//status",
+      - "@org_golang_google_grpc//:go_default_library"
+      - "@org_golang_google_grpc//codes"
+      - "@org_golang_google_grpc//status"
 rules:
   - name: proto_compile
     implementation: stackb:rules_proto:proto_compile
     visibility:
-      -  //visibility:public
+      - //visibility:public
   - name: proto_cc_library
     implementation: stackb:rules_proto:proto_cc_library
     visibility:
-      -  //visibility:public
+      - //visibility:public
     deps:
       - "@com_google_protobuf//:protobuf"
   - name: grpc_cc_library
     implementation: stackb:rules_proto:grpc_cc_library
     visibility:
-      -  //visibility:public
+      - //visibility:public
     deps:
       - "@com_github_grpc_grpc//:grpc++"
       - "@com_github_grpc_grpc//:grpc++_reflection"
   - name: proto_go_library
     implementation: stackb:rules_proto:proto_go_library
     visibility:
-      -  //visibility:public
+      - //visibility:public
     resolves:
       - "google/protobuf/([a-z]+).proto @org_golang_google_protobuf//types/known/${1}pb"
       - "google/protobuf/(descriptor|plugin).proto @org_golang_google_protobuf//types/${1}pb"
@@ -56,7 +56,7 @@ languages:
     rules:
       - proto_compile
   - name: go
-    plugins: 
+    plugins:
       - protoc-gen-go
       - protoc-gen-go-grpc
     rules:

--- a/pkg/protoc/resolver.go
+++ b/pkg/protoc/resolver.go
@@ -302,7 +302,6 @@ func ResolveImports(resolver ImportResolver, lang, impLang string, imports []str
 			deps = append(deps, first.Label)
 			// if r.options.Debug {
 			// 	r.options.Printf(lang, imp, "HIT", first.Label)
-			// }
 			// } else {
 			// 	if r.options.Debug {
 			// 		r.options.Printf(lang, imp, "MISS", resolver)

--- a/pkg/rule/rules_scala/scala_library.go
+++ b/pkg/rule/rules_scala/scala_library.go
@@ -281,6 +281,9 @@ func resolveScalaDeps(c *config.Config, ix *resolve.RuleIndex, r *rule.Rule, unr
 	resolvedDeps := make([]string, 0)
 
 	markResolved := func(imp string, to label.Label) {
+		if to == from {
+			return
+		}
 		resolvedDeps = append(resolvedDeps, to.String())
 		unresolvedDeps[imp] = nil
 	}

--- a/pkg/rule/rules_scala/scala_library.go
+++ b/pkg/rule/rules_scala/scala_library.go
@@ -302,9 +302,6 @@ func resolveScalaDeps(c *config.Config, ix *resolve.RuleIndex, r *rule.Rule, unr
 			log.Println(from, "multiple rules matched for scala import %q: %v", imp, result)
 			continue
 		}
-		if result[0].Label == from {
-			continue
-		}
 		markResolved(imp, result[0].Label)
 	}
 	if len(resolvedDeps) > 0 {


### PR DESCRIPTION
The scala_library.go rule does a late-resolve of imports in the `scala` resolve namespace (after `proto`).  These imports typically come in via `scalapb.options`.  There was a bug such that `@myworkspace//proto:proto` was not matching self label against `//proto:proto`.