### PR TITLE
scala resolve: suppress self-referential import warnings

### DIFF
--- a/pkg/rule/rules_scala/scala_library.go
+++ b/pkg/rule/rules_scala/scala_library.go
@@ -295,11 +295,11 @@ func resolveScalaDeps(
 	resolvedDeps := make([]string, 0)
 
 	markResolved := func(imp string, to label.Label) {
+		delete(unresolvedDeps, imp)
 		if to == from {
 			return
 		}
 		resolvedDeps = append(resolvedDeps, to.String())
-		unresolvedDeps[imp] = nil
 	}
 
 	for imp, err := range unresolvedDeps {


### PR DESCRIPTION
The previous PR https://github.com/stackb/rules_proto/pull/297 did resolve the bug, but warnings about unresolved dependencies were still printed.  This change fixes those unnecessary warnings.