### PR TITLE
feat: Propagate tags to proto_compiled_sources check/update targets

### DIFF
--- a/rules/proto_compiled_sources.bzl
+++ b/rules/proto_compiled_sources.bzl
@@ -23,6 +23,7 @@ def proto_compiled_sources(**kwargs):
     """
     name = kwargs.pop("name")
     srcs = kwargs.pop("srcs", [])
+    tags = kwargs.pop("tags", [])
     protoc = kwargs.pop("protoc", None)
     name_update = name + ".update"
     name_test = name + "_test"
@@ -39,6 +40,7 @@ def proto_compiled_sources(**kwargs):
         deps = [name],
         mode = "update",
         update_target_label_name = name_update,
+        tags = tags,
     )
 
     proto_compile_gencopy_test(
@@ -47,4 +49,5 @@ def proto_compiled_sources(**kwargs):
         deps = [name],
         mode = "check",
         update_target_label_name = name_update,
+        tags = tags,
     )


### PR DESCRIPTION
Background
---
Propagate tags to proto_compile_gencopy_run and proto_compile_gencopy_test targets