### PR TITLE
Remove unnecessary logging statement

### DIFF
--- a/pkg/protoc/package_config.go
+++ b/pkg/protoc/package_config.go
@@ -304,6 +304,5 @@ func RegisterStarlarkRule(c *config.Config, starlarkRule string) error {
 	}
 	configureError = err
 	Rules().MustRegisterRule(starlarkRule, impl)
-	log.Println("Registered rule:", starlarkRule, impl.Name())
 	return nil
 }


### PR DESCRIPTION
No need to log "Registered rule: foo" 