### PR TITLE
upgrade gazelle to v0.31.0; add new variables to proto_gazelle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/stackb/rules_proto
 go 1.15
 
 require (
-	github.com/bazelbuild/bazel-gazelle v0.27.0
+	github.com/bazelbuild/bazel-gazelle v0.31.0
 	github.com/bazelbuild/buildtools v0.0.0-20221004120235-7186f635531b
 	github.com/bazelbuild/rules_go v0.35.0
 	github.com/bmatcuk/doublestar v1.2.2


### PR DESCRIPTION
The latest version of Gazelle adds some new substitution variables. Without adding them to the `proto_gazelle` rule, you cannot upgrade.