### PR TITLE
fix: don't depend on JAVA_HOME

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,3 +17,7 @@ build --incompatible_java_common_parameters=false
 # HOME appears to be required by //pkg/plugin/grpc/grpc:grpc_test
 # (for github.com/bazelbuild/rules_go/go/tools/bazel_testing)
 test --action_env=HOME
+
+# Don't depend on a JAVA_HOME pointing at a system JDK
+# see https://github.com/bazelbuild/rules_jvm_external/issues/445
+build --repo_env=JAVA_HOME=../bazel_tools/jdk


### PR DESCRIPTION
On my Mac, I don't have a Java installation, so I can't run Coursier in a repo rule. This change fixes it.
Error looks like the following:

```
ERROR: An error occurred during the fetch of repository 'maven':
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_alexeagle/ae0af0834eef79816f461fa88cebe300/external/rules_jvm_external/coursier.bzl", line 795, column 13, in _coursier_fe
common --enable_platform_specific_config
tch_impl
		fail("Unable to run coursier: " + hasher_exec_result.stderr)
Error in fail: Unable to run coursier: The operation couldn’t be completed. Unable to locate a Java Runtime.
```