### PR TITLE
Migrate timestamp dependency to external proto repository

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -69,7 +69,4 @@ filegroup(
 
 npm_link_all_packages(
     name = "node_modules",
-    # imported_links = [
-    #     "@protoapis//google/protobuf:timestamp_ts_proto_pkg",
-    # ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -69,4 +69,7 @@ filegroup(
 
 npm_link_all_packages(
     name = "node_modules",
+    # imported_links = [
+    #     "@protoapis//google/protobuf:timestamp_ts_proto_pkg",
+    # ],
 )

--- a/cmd/gazelle/internal/module/BUILD.bazel
+++ b/cmd/gazelle/internal/module/BUILD.bazel
@@ -17,9 +17,3 @@ filegroup(
     ],
     visibility = ["//visibility:public"],
 )
-
-alias(
-    name = "go_default_library",
-    actual = ":module",
-    visibility = ["//:__subpackages__"],
-)

--- a/cmd/gazelle/internal/wspace/BUILD.bazel
+++ b/cmd/gazelle/internal/wspace/BUILD.bazel
@@ -24,9 +24,3 @@ filegroup(
     ],
     visibility = ["//visibility:public"],
 )
-
-alias(
-    name = "go_default_library",
-    actual = ":wspace",
-    visibility = ["//:__subpackages__"],
-)

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -101,24 +101,8 @@
 # gazelle:proto_language python rule proto_python_library
 # gazelle:proto_language python rule grpc_py_library
 
-## ts-proto ##
-# gazelle:proto_plugin ts_proto implementation stephenh:ts-proto:protoc-gen-ts-proto
-# gazelle:proto_plugin ts_proto option emitImportedFiles=false
-# gazelle:proto_plugin ts_proto option esModuleInterop=true
-# gazelle:proto_rule proto_ts_library implementation stackb:rules_proto:proto_ts_library
-# gazelle:proto_rule proto_ts_library visibility //visibility:public
-# gazelle:proto_rule proto_ts_library deps //:node_modules/@nestjs/microservices
-# gazelle:proto_rule proto_ts_library deps //:node_modules/@types/node
-# gazelle:proto_rule proto_ts_library deps //:node_modules/long
-# gazelle:proto_rule proto_ts_library deps //:node_modules/protobufjs
-# gazelle:proto_rule proto_ts_library deps //:node_modules/rxjs
-
-# Set an out_dir so that we don't conflict with the closurejs output
-# gazelle:proto_rule proto_ts_library attr out_dir ts
-
-# gazelle:proto_language ts_proto plugin ts_proto
-# gazelle:proto_language ts_proto rule proto_compile
-# gazelle:proto_language ts_proto rule proto_ts_library
+## ts-proto (see config.yaml for configuration) ##
+# gazelle:proto_language ts_proto enable true
 
 ## closure + grpc.js ##
 # gazelle:proto_plugin closure_js implementation builtin:js:closure

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -10,7 +10,6 @@ plugins:
     implementation: stephenh:ts-proto:protoc-gen-ts-proto
     options:
       - "emitImportedFiles=false"
-      - "esModuleInterop=true"
   - name: protoc-gen-go
     implementation: golang:protobuf:protoc-gen-go
     deps:

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -55,11 +55,9 @@ rules:
     visibility:
       - //visibility:public
     deps:
-      - "@//:node_modules/@nestjs/microservices"
       - "@//:node_modules/@types/node"
       - "@//:node_modules/long"
       - "@//:node_modules/protobufjs"
-      - "@//:node_modules/rxjs"
 languages:
   - name: cpp
     plugins:

--- a/example/person/BUILD.bazel
+++ b/example/person/BUILD.bazel
@@ -151,7 +151,7 @@ proto_ts_library(
         "//:node_modules/long",
         "//:node_modules/protobufjs",
         "//example/place:place_ts_proto",
-        "@protoapis//google/protobuf:timestamp_ts_proto",
+        "@protoapis//google/protobuf:timestamp_ts_proto",  # keep
     ],
 )
 

--- a/example/person/BUILD.bazel
+++ b/example/person/BUILD.bazel
@@ -151,7 +151,7 @@ proto_ts_library(
         "//:node_modules/long",
         "//:node_modules/protobufjs",
         "//example/place:place_ts_proto",
-        "//google/protobuf:timestamp_ts_proto",
+        "@protoapis//google/protobuf:timestamp_ts_proto",
     ],
 )
 

--- a/example/routeguide/BUILD.bazel
+++ b/example/routeguide/BUILD.bazel
@@ -17,7 +17,8 @@ load("@build_stack_rules_proto//rules/ts:proto_ts_library.bzl", "proto_ts_librar
 load("@build_stack_rules_proto//rules:proto_compile.bzl", "proto_compile")
 
 # gazelle:proto_plugin ts_proto option nestJs=true
-# gazelle:proto_rule proto_ts_library deps @npm_tsc//@nestjs/microservices
+# gazelle:proto_rule proto_ts_library deps //:node_modules/@nestjs/microservices
+# gazelle:proto_rule proto_ts_library deps //:node_modules/rxjs
 
 filegroup(
     name = "features",
@@ -58,7 +59,7 @@ proto_library(
 
 grpc_closure_js_library(
     name = "routeguide_grpc_closure_js_library",
-    srcs = ["routeguide.grpc.js"],
+    srcs = [],
     suppress = [
         "JSC_IMPLICITLY_NONNULL_JSDOC",
         "JSC_UNUSED_LOCAL_ASSIGNMENT",

--- a/example/thing/BUILD.bazel
+++ b/example/thing/BUILD.bazel
@@ -27,6 +27,7 @@ proto_closure_js_library(
         "JSC_UNUSED_LOCAL_ASSIGNMENT",
     ],
     visibility = ["//visibility:public"],
+    exports = [],
 )
 
 proto_compile(
@@ -120,7 +121,7 @@ proto_compile(
     name = "thing_ts_proto_compile",
     options = {"@build_stack_rules_proto//plugin/stephenh/ts-proto:protoc-gen-ts-proto": [
         "emitImportedFiles=false",
-        "Mgoogle/protobuf/timestamp.proto=../../external/protoapis/google/protobuf/timestamp",
+        "Mgoogle/protobuf/timestamp.proto=../../external/protoapis/google/protobuf/timestamp",  # keep
     ]},
     outputs = ["thing.ts"],
     plugins = ["@build_stack_rules_proto//plugin/stephenh/ts-proto:protoc-gen-ts-proto"],
@@ -134,7 +135,7 @@ proto_ts_library(
     deps = [
         "//:node_modules/long",
         "//:node_modules/protobufjs",
-        "@protoapis//google/protobuf:timestamp_ts_proto",
+        "@protoapis//google/protobuf:timestamp_ts_proto",  # keep
     ],
 )
 

--- a/example/thing/BUILD.bazel
+++ b/example/thing/BUILD.bazel
@@ -120,6 +120,7 @@ proto_compile(
     name = "thing_ts_proto_compile",
     options = {"@build_stack_rules_proto//plugin/stephenh/ts-proto:protoc-gen-ts-proto": [
         "emitImportedFiles=false",
+        "Mgoogle/protobuf/timestamp.proto=../../external/protoapis/google/protobuf/timestamp",
     ]},
     outputs = ["thing.ts"],
     plugins = ["@build_stack_rules_proto//plugin/stephenh/ts-proto:protoc-gen-ts-proto"],
@@ -133,7 +134,7 @@ proto_ts_library(
     deps = [
         "//:node_modules/long",
         "//:node_modules/protobufjs",
-        "//google/protobuf:timestamp_ts_proto",
+        "@protoapis//google/protobuf:timestamp_ts_proto",
     ],
 )
 

--- a/pkg/protoc/BUILD.bazel
+++ b/pkg/protoc/BUILD.bazel
@@ -80,6 +80,8 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
         "@com_github_stretchr_testify//assert",
+        "@net_starlark_go//starlark",
+        "@net_starlark_go//starlarkstruct",
     ],
 )
 

--- a/proto_repositories.bzl
+++ b/proto_repositories.bzl
@@ -11,7 +11,6 @@ def proto_repositories():
             "gazelle:proto_language cpp enable false",
             "gazelle:proto_language ts enable true",
             "gazelle:proto_language descriptor enable true",
-            "gazelle:proto_rule proto_ts_library attr out_dir ts",
         ],
         build_file_expunge = True,
         build_file_proto_mode = "file",

--- a/rules/private/proto_repository_tools_srcs.bzl
+++ b/rules/private/proto_repository_tools_srcs.bzl
@@ -43,7 +43,6 @@ PROTO_REPOSITORY_TOOLS_SRCS = [
     "@build_stack_rules_proto//example/thing:BUILD.bazel",
     "@build_stack_rules_proto//example/toolchain/prebuilt:BUILD.bazel",
     "@build_stack_rules_proto//example/toolchain/standard:BUILD.bazel",
-    "@build_stack_rules_proto//google/protobuf:BUILD",
     "@build_stack_rules_proto//language/example:BUILD.bazel",
     "@build_stack_rules_proto//language/example:example.go",
     "@build_stack_rules_proto//language/protobuf:BUILD.bazel",


### PR DESCRIPTION
Removes vendored copy of timestamp.proto that was introduced in #339