### PR TITLE
Support for gazelle 0.35.0

### DIFF
--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -103,19 +103,19 @@ proto_dependency(
     visibility = ["//visibility:public"],
 )
 
-# Release: v0.31.0
+# Release: v0.35.0
 # TargetCommitish: master
-# Date: 2023-05-27 18:23:20 +0000 UTC
-# URL: https://github.com/bazelbuild/bazel-gazelle/releases/tag/v0.31.0
-# Size: 1870962 (1.9 MB)
+# Date: 2023-12-21 18:18:45 +0000 UTC
+# URL: https://github.com/bazelbuild/bazel-gazelle/releases/tag/v0.35.0
+# Size: 1780790 (1.7 MB)
 proto_dependency(
     name = "bazel_gazelle",
     patch_args = ["-p1"],
     patches = ["@build_stack_rules_proto//third_party:bazel-gazelle-revert-1152.patch"],
     repository_rule = "http_archive",
-    sha256 = "bc9a8c259ad2eb54dd89404979c097451df8f2dc64852c9f38d2b7a248f84f32",
-    strip_prefix = "bazel-gazelle-0.31.0",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/v0.31.0.tar.gz"],
+    sha256 = "a0ee1d304f7caa46680ba06bdef0e5d9ec8815f6e01ec29398efd13256598c3f",
+    strip_prefix = "bazel-gazelle-0.35.0",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/v0.35.0.tar.gz"],
     deps = [":io_bazel_rules_go"],
 )
 

--- a/deps/core_deps.bzl
+++ b/deps/core_deps.bzl
@@ -30,10 +30,10 @@ def bazel_gazelle():
     _maybe(
         http_archive,
         name = "bazel_gazelle",
-        sha256 = "bc9a8c259ad2eb54dd89404979c097451df8f2dc64852c9f38d2b7a248f84f32",
-        strip_prefix = "bazel-gazelle-0.31.0",
+        sha256 = "a0ee1d304f7caa46680ba06bdef0e5d9ec8815f6e01ec29398efd13256598c3f",
+        strip_prefix = "bazel-gazelle-0.35.0",
         urls = [
-            "https://github.com/bazelbuild/bazel-gazelle/archive/v0.31.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/archive/v0.35.0.tar.gz",
         ],
         patches = [
             "@build_stack_rules_proto//third_party:bazel-gazelle-revert-1152.patch",

--- a/pkg/protoc/resolver.go
+++ b/pkg/protoc/resolver.go
@@ -196,12 +196,8 @@ func (r *resolver) Resolve(lang, impLang, imp string) []resolve.FindResult {
 	}
 	if got, ok := known[imp]; ok {
 		res := make([]resolve.FindResult, len(got))
-		// use last-wins semantics by providing FindResults in reverse to how
-		// they were provided.
-		var index int
-		for i := len(got) - 1; i >= 0; i-- {
-			res[index] = resolve.FindResult{Label: got[i]}
-			index++
+		for i, l := range got {
+			res[i] = resolve.FindResult{Label: l}
 		}
 		return res
 	}
@@ -270,20 +266,16 @@ func (r *resolver) Install(c *config.Config) {
 	// The resolve config has already processed resolve directives, and there's
 	// no public API. Take somewhat extreme measures to augment it's internal
 	// override list via unsafe memory reallocation.
-	overrides := make([]overrideSpec, 0)
+	overrides := make(overrideSpec, 0)
 
 	for key, known := range r.known {
 		lang, impLang := keyLang(key)
 		for imp, lbls := range known {
 			for _, lbl := range lbls {
-				overrides = append(overrides, overrideSpec{
-					imp: resolve.ImportSpec{
-						Lang: impLang,
-						Imp:  imp,
-					},
+				overrides[overrideKey{
+					imp:  resolve.ImportSpec{Lang: impLang, Imp: imp},
 					lang: lang,
-					dep:  lbl,
-				})
+				}] = lbl
 			}
 		}
 	}
@@ -333,31 +325,36 @@ func getResolveConfig(c *config.Config) interface{} {
 
 // rewriteResolveConfigOverrides reads the existing private attribute and
 // appends more overrides.
-func rewriteResolveConfigOverrides(rc interface{}, more []overrideSpec) {
+func rewriteResolveConfigOverrides(rc interface{}, more overrideSpec) {
 	rcv := reflect.ValueOf(rc).Elem()
 	val := reflect.Indirect(rcv)
 	member := val.FieldByName("overrides")
 	ptrToOverrides := unsafe.Pointer(member.UnsafeAddr())
-	overrides := (*[]overrideSpec)(ptrToOverrides)
+	overrides := (*overrideSpec)(ptrToOverrides)
 
 	// create new array: FindRuleWithOverride searches last entries first, so
 	// respect the users own resolve directives by putting them last
-	newOverrides := make([]overrideSpec, 0)
-	newOverrides = append(newOverrides, more...)
-	newOverrides = append(newOverrides, *overrides...)
+	newOverrides := make(overrideSpec, 0)
+	for k, v := range more {
+		newOverrides[k] = v
+	}
+	for k, v := range *overrides {
+		newOverrides[k] = v
+	}
 
 	// reassign memory value
 	*overrides = newOverrides
 }
 
+type overrideKey struct {
+	imp  resolve.ImportSpec
+	lang string
+}
+
 // overrideSpec is a copy of the same private type in resolve/config.go.  It must be
 // kept in sync with the original to avoid discrepancy with the expected memory
 // layout.
-type overrideSpec struct {
-	imp  resolve.ImportSpec
-	lang string
-	dep  label.Label
-}
+type overrideSpec map[overrideKey]label.Label
 
 func langKey(lang, impLang string) string {
 	return lang + " " + impLang
@@ -367,3 +364,4 @@ func keyLang(key string) (string, string) {
 	parts := strings.SplitN(key, " ", 2)
 	return parts[0], parts[1]
 }
+


### PR DESCRIPTION
The latest version of gazelle updated how the overrides are stored. This ensures that rules_proto works with gazelle 0.35.0
Note that this is a breaking change and makes rules_proto incompatible with older versions of gazelle.

Fixes #356
