### PR TITLE
MODULE.bazel: mark module version using placeholder 0.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,6 +2,7 @@
 
 module(
     name = "build_stack_rules_proto",
+    version = "0.0.0",
     compatibility_level = 1,
 )
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -11,9 +11,7 @@ buildifier_test(
     name = "buildifier.check",
     size = "small",
     diff_command = "diff",
-    exclude_patterns = [
-        "./vendor/*",
-    ],
+    exclude_patterns = ["./vendor/*"],
     lint_mode = "warn",
     mode = "diff",
     no_sandbox = True,


### PR DESCRIPTION
Without the version placeholder, release/publish script adds it in after the compatibility attr, causing buildifier.check to fail.